### PR TITLE
Add rejseplanen skill for Danish public transport

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Added
+
+- **rejseplanen** — Danish public transport journey planning via the Rejseplanen API (6 commands: location, trip, departures, arrivals, nearby, disruptions)
+
 ## [1.0.0] - 2026-03-13
 
 ### Added

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -46,6 +46,10 @@
     "salling-food-waste": {
       "source": "skills/salling-food-waste/SKILL.md",
       "sourceType": "local"
+    },
+    "rejseplanen": {
+      "source": "skills/rejseplanen/SKILL.md",
+      "sourceType": "local"
     }
   }
 }

--- a/skills/rejseplanen/SKILL.md
+++ b/skills/rejseplanen/SKILL.md
@@ -1,0 +1,395 @@
+---
+name: rejseplanen
+version: 1.0.0
+description: >
+  Make sure to use this skill whenever the user asks about public transport in Denmark,
+  train schedules, bus times, metro departures, journey planning between Danish cities,
+  or travel routes using Danish public transport — even if they just ask how to get from
+  one place to another in Denmark without naming Rejseplanen specifically.
+  Also use this skill when the user asks about departures or arrivals at a Danish station,
+  next train/bus/metro from a stop, or wants to look up a Danish transit stop or station.
+  Trigger phrases include: rejseplanen, offentlig transport, tog, bus, metro, s-tog, letbane,
+  rejse, afgange, ankomster, køreplan, how to get from, next train, next bus, departures from,
+  arrivals at, rejsetid, togplan, bustider, DSB, Movia, Midttrafik, Nordjyllands Trafikselskab,
+  FynBus, Sydtrafik, offentlig transport Danmark, public transport Denmark, Danish train,
+  Danish bus, hvornår kører, hvordan kommer jeg til, find station, find stop,
+  disruptions, driftsforstyrrelser, forsinkelser, delays, nearby stops, nærmeste stationer,
+  cykel, bike access, wheelchair, kørestol, stoppesteder i nærheden.
+context: fork
+allowed-tools: Bash(bun run skills/rejseplanen/cli/src/cli.ts *)
+---
+
+# Rejseplanen Public Transport Skill
+
+Plan journeys, check departures/arrivals, and search for stops/stations across all Danish public transport (trains, buses, metro, light rail) via the [Rejseplanen API](https://www.rejseplanen.dk). Requires an API access ID — users must set the `REJSEPLANEN_ACCESS_ID` environment variable.
+
+## Setup
+
+### How to obtain `REJSEPLANEN_ACCESS_ID`
+
+1. Go to the [Rejseplanen API access page](https://help.rejseplanen.dk/hc/da/articles/214174465-Adgang-til-Rejseplanens-API)
+2. Fill out the request form with your name, email, and a brief description of your use case
+3. Rejseplanen will email you an access ID (typically within a few business days)
+4. Set it as an environment variable:
+
+```bash
+export REJSEPLANEN_ACCESS_ID=your_access_id_here
+```
+
+To make it permanent, add the export line to your shell profile (`~/.bashrc`, `~/.zshrc`, etc.).
+
+If `REJSEPLANEN_ACCESS_ID` is not set, the CLI will exit with a clear error message.
+
+## When to use this skill
+
+Invoke this skill when the user wants to:
+
+- Plan a journey between two locations in Denmark (e.g., "How do I get from Aarhus to Copenhagen?")
+- Check ticket prices / fares for a journey (included by default in trip output)
+- Check upcoming departures from a Danish stop/station
+- Check upcoming arrivals at a Danish stop/station
+- Search for a stop or station by name
+- Look up train, bus, metro, or light rail schedules in Denmark
+- Check service disruptions, delays, or travel alerts
+- Find nearby stops/stations by coordinates
+- Check real-time delay information for departures/arrivals
+- Check bike or wheelchair accessibility for a journey
+
+## Commands
+
+### Search for stops/stations
+
+```bash
+bun run skills/rejseplanen/cli/src/cli.ts location --query <name> [flags]
+```
+
+Key flags:
+- `--query <name>` — Search string (required)
+- `--max <n>` — Max results (default: 10)
+- `--type <S|A|P|ALL>` — Filter by type: S=stop, A=address, P=POI, ALL=all (default: ALL)
+- `--format json|table|plain`
+
+### Plan a trip
+
+```bash
+bun run skills/rejseplanen/cli/src/cli.ts trip --origin <id-or-name> --destination <id-or-name> [flags]
+```
+
+Key flags:
+- `--origin <id-or-name>` — Origin stop ID or name (required)
+- `--destination <id-or-name>` — Destination stop ID or name (required)
+- `--date <YYYY-MM-DD>` — Travel date (default: today)
+- `--time <HH:MM>` — Travel time (default: now)
+- `--arrive-by` — Search for arrival time instead of departure
+- `--results <n>` — Number of trip results, 1-6 (default: 5)
+- `--no-fares` — Exclude fare/pricing (fares included by default)
+- `--via <id-or-name>` — Via stop ID or name
+- `--stops` — Show intermediate stops for each leg
+- `--scroll <token>` — Scroll token for pagination (use scrollEarlier/scrollLater from output)
+- `--format json|table|plain`
+
+### Check departures from a stop
+
+```bash
+bun run skills/rejseplanen/cli/src/cli.ts departures --stop <id> [flags]
+```
+
+Key flags:
+- `--stop <id>` — Stop ID from location search (required)
+- `--date <YYYY-MM-DD>` — Date (default: today)
+- `--time <HH:MM>` — Time (default: now)
+- `--duration <minutes>` — Time window in minutes, 0-1439 (default: 60)
+- `--max <n>` — Max results (default: 20)
+- `--format json|table|plain`
+
+### Check arrivals at a stop
+
+```bash
+bun run skills/rejseplanen/cli/src/cli.ts arrivals --stop <id> [flags]
+```
+
+Same flags as `departures`.
+
+### Find nearby stops
+
+```bash
+bun run skills/rejseplanen/cli/src/cli.ts nearby --lat <latitude> --lon <longitude> [flags]
+```
+
+Key flags:
+- `--lat <n>` — Latitude (required)
+- `--lon <n>` — Longitude (required)
+- `--radius <meters>` — Search radius (default: 1000)
+- `--max <n>` — Max results (default: 10)
+- `--format json|table|plain`
+
+### Check service disruptions
+
+```bash
+bun run skills/rejseplanen/cli/src/cli.ts disruptions [flags]
+```
+
+Key flags:
+- `--stop <id>` — Filter by stop ID
+- `--line <name>` — Filter by line
+- `--date <YYYY-MM-DD>` — Date (default: today)
+- `--time <HH:MM>` — Time (default: now)
+- `--max <n>` — Max results (default: 20)
+- `--format json|table|plain`
+
+---
+
+## Natural workflow: location -> trip / departures / arrivals / nearby / disruptions
+
+1. Use `location` to find a stop and get its ID, or use `nearby` to find stops near coordinates
+2. Use `trip` to plan a journey between two stops (fares included by default)
+3. Use `departures`/`arrivals` to check schedules and real-time delays
+4. Use `disruptions` to check for service alerts before traveling
+
+```bash
+# Step 1: find stop IDs
+bun run skills/rejseplanen/cli/src/cli.ts location --query "København H"
+bun run skills/rejseplanen/cli/src/cli.ts location --query "Aarhus H"
+
+# Step 1 (alt): find nearby stops by coordinates
+bun run skills/rejseplanen/cli/src/cli.ts nearby --lat 55.6727 --lon 12.5655
+
+# Step 2: plan a trip (fares included by default)
+bun run skills/rejseplanen/cli/src/cli.ts trip --origin "8600626" --destination "8600079"
+
+# Step 3: check departures
+bun run skills/rejseplanen/cli/src/cli.ts departures --stop "8600626"
+
+# Step 4: check disruptions
+bun run skills/rejseplanen/cli/src/cli.ts disruptions
+```
+
+---
+
+## Usage examples
+
+### Find a station
+
+```bash
+bun run skills/rejseplanen/cli/src/cli.ts location --query "Nørreport"
+```
+
+### Plan a trip from Copenhagen to Aarhus
+
+```bash
+bun run skills/rejseplanen/cli/src/cli.ts trip --origin "København H" --destination "Aarhus H" --date 2026-03-20 --time 08:00
+```
+
+### Next departures from København H
+
+```bash
+bun run skills/rejseplanen/cli/src/cli.ts departures --stop "8600626" --duration 30
+```
+
+### Arrivals at Odense in table format
+
+```bash
+bun run skills/rejseplanen/cli/src/cli.ts arrivals --stop "8600067" --format table
+```
+
+### Find stops near a location
+
+```bash
+bun run skills/rejseplanen/cli/src/cli.ts nearby --lat 55.6727 --lon 12.5655 --radius 500
+```
+
+### Check current disruptions
+
+```bash
+bun run skills/rejseplanen/cli/src/cli.ts disruptions
+```
+
+### Trip with intermediate stops via Odense
+
+```bash
+bun run skills/rejseplanen/cli/src/cli.ts trip --origin "København H" --destination "Aarhus H" --via "Odense" --stops
+```
+
+---
+
+## JSON output shapes
+
+### location output
+
+```json
+{
+  "type": "rejseplanen_location",
+  "query": "København",
+  "locations": [
+    {
+      "id": "8600626",
+      "name": "København H",
+      "lat": 55.672778,
+      "lon": 12.564444,
+      "type": "ST"
+    }
+  ],
+  "count": 1
+}
+```
+
+### trip output
+
+```json
+{
+  "type": "rejseplanen_trip",
+  "origin": "København H",
+  "destination": "Aarhus H",
+  "date": "2026-03-20",
+  "time": "08:00",
+  "via": "Odense",
+  "scrollEarlier": "token...",
+  "scrollLater": "token...",
+  "trips": [
+    {
+      "origin": "København H",
+      "destination": "Aarhus H",
+      "departure": "08:12",
+      "arrival": "11:23",
+      "duration": "3:11",
+      "changes": 0,
+      "legs": [
+        {
+          "name": "IC 123",
+          "type": "IC",
+          "origin": "København H",
+          "destination": "Aarhus H",
+          "departure": "08:12",
+          "arrival": "11:23",
+          "track": "7",
+          "direction": "Aarhus H",
+          "cancelled": false,
+          "rtDeparture": null,
+          "rtArrival": null,
+          "delayed": true,
+          "delayMinutes": 5,
+          "notes": [{"type": "bike", "text": "Cykel reservation påkrævet"}],
+          "stops": [{"name": "Høje Taastrup St.", "arrival": "08:27", "departure": "08:28"}]
+        }
+      ]
+    }
+  ],
+  "tripCount": 1
+}
+```
+
+### departures output
+
+```json
+{
+  "type": "rejseplanen_departures",
+  "stop": "8600626",
+  "date": "2026-03-20",
+  "time": "08:00",
+  "departures": [
+    {
+      "name": "IC 123",
+      "line": "IC",
+      "direction": "Aarhus H",
+      "date": "2026-03-20",
+      "time": "08:12",
+      "rtDate": null,
+      "rtTime": null,
+      "track": "7",
+      "cancelled": false,
+      "stopId": "8600626",
+      "delayed": true,
+      "delayMinutes": 5,
+      "notes": [{"type": "bike", "text": "Cykel reservation påkrævet"}]
+    }
+  ],
+  "count": 1
+}
+```
+
+### arrivals output
+
+```json
+{
+  "type": "rejseplanen_arrivals",
+  "stop": "8600626",
+  "date": "2026-03-20",
+  "time": "08:00",
+  "arrivals": [
+    {
+      "name": "IC 456",
+      "line": "IC",
+      "origin": "Aarhus H",
+      "date": "2026-03-20",
+      "time": "11:23",
+      "rtDate": null,
+      "rtTime": null,
+      "track": "7",
+      "cancelled": false,
+      "stopId": "8600626",
+      "delayed": true,
+      "delayMinutes": 5,
+      "notes": [{"type": "bike", "text": "Cykel reservation påkrævet"}]
+    }
+  ],
+  "count": 1
+}
+```
+
+### nearby output
+
+```json
+{
+  "type": "rejseplanen_nearby",
+  "lat": 55.672736,
+  "lon": 12.565558,
+  "radius": 1000,
+  "stops": [
+    {
+      "id": "8600626",
+      "name": "København H",
+      "lat": 55.672736,
+      "lon": 12.565558,
+      "dist": 120,
+      "type": "ST"
+    }
+  ],
+  "count": 1
+}
+```
+
+### disruptions output
+
+```json
+{
+  "type": "rejseplanen_disruptions",
+  "date": "2026-03-18",
+  "disruptions": [
+    {
+      "id": "HIM_123",
+      "subject": "Sporarbejde København H - Ringsted",
+      "message": "Full disruption text...",
+      "priority": 2,
+      "startDate": "2026-03-18",
+      "startTime": "04:00",
+      "endDate": "2026-03-20",
+      "endTime": "23:59",
+      "affectedStops": ["København H", "Ringsted St."],
+      "affectedLines": ["IC", "Re"]
+    }
+  ],
+  "count": 1
+}
+```
+
+---
+
+## Output formats
+
+| Format | Best for |
+|--------|----------|
+| `json` | Default — programmatic use, full data |
+| `table` | Quick human-readable overview |
+| `plain` | Easy reading of individual items |
+
+All errors are written to **stderr** as `{ "error": "...", "code": "..." }` and the process exits with code `1`.

--- a/skills/rejseplanen/cli/README.md
+++ b/skills/rejseplanen/cli/README.md
@@ -1,0 +1,403 @@
+# Rejseplanen CLI
+
+CLI for Danish public transport journey planning via the [Rejseplanen API 2.0](https://www.rejseplanen.dk).
+
+## Authentication
+
+All requests require an `accessId` query parameter. The CLI reads it from the `REJSEPLANEN_ACCESS_ID` environment variable.
+
+### How to obtain an access ID
+
+1. Go to the [Rejseplanen API access page](https://help.rejseplanen.dk/hc/da/articles/214174465-Adgang-til-Rejseplanens-API)
+2. Fill out the request form with your name, email, and a brief description of your use case
+3. Rejseplanen will email you an access ID (typically within a few business days)
+4. The access ID is a string token (e.g., `a1b2c3d4-e5f6-7890-abcd-ef1234567890`)
+
+Once you have your access ID, set it as an environment variable:
+
+```bash
+export REJSEPLANEN_ACCESS_ID=your_access_id_here
+```
+
+To make it permanent, add the export to your shell profile (`~/.bashrc`, `~/.zshrc`, etc.).
+
+## API Base URL
+
+```
+https://www.rejseplanen.dk/api/
+```
+
+All requests include `format=json` to get JSON responses.
+
+---
+
+## Commands
+
+### `location` — Search stops/stations
+
+Search for stops, addresses, and points of interest by name.
+
+**API endpoint:** `GET /location.name`
+
+**Flags:**
+
+| Flag | Type | Required | Default | Description |
+|------|------|----------|---------|-------------|
+| `--query` | string | yes | — | Search string |
+| `--max` | number | no | 10 | Max results (1-50) |
+| `--type` | string | no | ALL | Filter: S=stop, A=address, P=POI, ALL=all |
+| `--format` | string | no | json | Output format: json, table, plain |
+
+**API parameters mapping:**
+- `--query` → `input`
+- `--max` → `maxNo`
+- `--type` → `type`
+
+**JSON output:**
+
+```json
+{
+  "type": "rejseplanen_location",
+  "query": "København",
+  "locations": [
+    {
+      "id": "8600626",
+      "name": "København H",
+      "lat": 55.672778,
+      "lon": 12.564444,
+      "type": "ST"
+    }
+  ],
+  "count": 1
+}
+```
+
+Location types: `"ST"` (stop/station), `"ADR"` (address), `"POI"` (point of interest).
+
+The API returns locations in `stopLocationOrCoordLocation` array. Each entry is either a `StopLocation` (with `extId`, `name`, coordinates) or a `CoordLocation` (with `name`, coordinates, `type`).
+
+---
+
+### `trip` — Plan a journey
+
+Plan a trip between two locations.
+
+**API endpoint:** `GET /trip`
+
+**Flags:**
+
+| Flag | Type | Required | Default | Description |
+|------|------|----------|---------|-------------|
+| `--origin` | string | yes | — | Origin stop ID or name |
+| `--destination` | string | yes | — | Destination stop ID or name |
+| `--date` | string | no | today | Travel date (YYYY-MM-DD) |
+| `--time` | string | no | now | Travel time (HH:MM) |
+| `--arrive-by` | boolean | no | false | Search by arrival time |
+| `--results` | number | no | 5 | Number of trips (1-6) |
+| `--no-fares` | boolean | no | false | Exclude fare/pricing (fares included by default) |
+| `--via` | string | no | — | Via stop ID or name |
+| `--stops` | boolean | no | false | Show intermediate stops for each leg |
+| `--scroll` | string | no | — | Scroll token for earlier/later results |
+| `--format` | string | no | json | Output format: json, table, plain |
+
+**API parameters mapping:**
+- If `--origin` looks like a stop ID (digits only), use `originExtId` directly; otherwise resolve via `/location.name` first
+- If `--destination` looks like a stop ID, use `destExtId` directly; otherwise resolve via `/location.name` first
+- `--date` → `date` (YYYY-MM-DD)
+- `--time` → `time` (HH:MM)
+- `--arrive-by` → `searchForArrival=1`
+- `--results` → `numF` (forward results)
+- `--via` → resolve via `/location.name` if name, then `viaExtId`
+- `--scroll` → `ctx`
+- Fares are included by default; use `--no-fares` to exclude
+
+**JSON output:**
+
+```json
+{
+  "type": "rejseplanen_trip",
+  "origin": "København H",
+  "destination": "Aarhus H",
+  "via": "Odense",
+  "date": "2026-03-20",
+  "time": "08:00",
+  "trips": [
+    {
+      "origin": "København H",
+      "destination": "Aarhus H",
+      "departure": "08:12",
+      "arrival": "11:23",
+      "duration": "3:11",
+      "changes": 0,
+      "legs": [
+        {
+          "name": "IC 123",
+          "type": "IC",
+          "origin": "København H",
+          "destination": "Aarhus H",
+          "departure": "08:12",
+          "arrival": "11:23",
+          "track": "7",
+          "direction": "Aarhus H",
+          "cancelled": false,
+          "delayed": false,
+          "delayMinutes": 0,
+          "rtDeparture": null,
+          "rtArrival": null,
+          "notes": [],
+          "stops": []
+        }
+      ],
+      "fares": [
+        {
+          "passenger": "Adult",
+          "product": "EasyTrip",
+          "class": "Standard",
+          "price": 416.00,
+          "currency": "DKK"
+        },
+        {
+          "passenger": "Child",
+          "product": "EasyTrip",
+          "class": "Standard",
+          "price": 208.00,
+          "currency": "DKK"
+        }
+      ]
+    }
+  ],
+  "tripCount": 1,
+  "scrollEarlier": "B|T|...",
+  "scrollLater": "F|T|..."
+}
+```
+
+The `fares` array is included by default. Use `--no-fares` to exclude it. Prices are Rejsekort EasyTrip standard class fares in DKK. Passenger types: Adult, Child, Pensioner, Youth, Halvpris (half-price card holder).
+
+The `via` field is only present when `--via` is used. The `stops` array in each leg is populated when `--stops` is passed, showing intermediate stops with name, arrival/departure times, and track. The `scrollEarlier` and `scrollLater` tokens can be passed back via `--scroll` to paginate through results.
+
+The API returns `Trip` array. Each Trip has a `LegList.Leg` array. Each leg has `Origin`, `Destination`, `Product` (name, line, catOutL), `direction`, `cancelled`, real-time data (`rtDepTime`, `rtArrTime`), track info, `delayed` (boolean), `delayMinutes` (computed from real-time vs scheduled), and `notes` (array of `{type, text}` objects — same types as departures/arrivals). The scroll context is returned in `scrB` (earlier) and `scrF` (later) on the response.
+
+For walking legs, `type` is `"WALK"` and `name` is `"Walk"`.
+
+Duration is calculated as difference between first leg departure and last leg arrival.
+
+---
+
+### `departures` — Departure board
+
+Show upcoming departures from a stop.
+
+**API endpoint:** `GET /departureBoard`
+
+**Flags:**
+
+| Flag | Type | Required | Default | Description |
+|------|------|----------|---------|-------------|
+| `--stop` | string | yes | — | Stop ID |
+| `--date` | string | no | today | Date (YYYY-MM-DD) |
+| `--time` | string | no | now | Time (HH:MM) |
+| `--duration` | number | no | 60 | Time window in minutes (0-1439) |
+| `--max` | number | no | 20 | Max results |
+| `--format` | string | no | json | Output format: json, table, plain |
+
+**API parameters mapping:**
+- `--stop` → `id`
+- `--date` → `date` (YYYY-MM-DD)
+- `--time` → `time` (HH:MM)
+- `--duration` → `duration`
+- `--max` → `maxJourneys`
+
+**JSON output:**
+
+```json
+{
+  "type": "rejseplanen_departures",
+  "stop": "8600626",
+  "date": "2026-03-20",
+  "time": "08:00",
+  "departures": [
+    {
+      "name": "IC 123",
+      "line": "IC",
+      "direction": "Aarhus H",
+      "date": "2026-03-20",
+      "time": "08:12",
+      "rtDate": null,
+      "rtTime": null,
+      "track": "7",
+      "cancelled": false,
+      "stopId": "8600626",
+      "delayed": false,
+      "delayMinutes": 0,
+      "notes": []
+    }
+  ],
+  "count": 1
+}
+```
+
+The API returns `Departure` array (or `DepartureBoard.Departure`). Each has `name`, `line` (from Product), `direction`, `date`, `time`, `rtDate`, `rtTime`, `track`, `cancelled`, `stopId`, `delayed` (boolean), `delayMinutes` (computed from real-time vs scheduled), and `notes` (array of `{type, text}` objects). Note types: `"bike"` (from API key `FR`), `"accessibility"` (from API key `BE`), `"info"` (all others). Internal notes (API type `I`) are filtered out.
+
+---
+
+### `arrivals` — Arrival board
+
+Show upcoming arrivals at a stop.
+
+**API endpoint:** `GET /arrivalBoard`
+
+**Flags:**
+
+Same as `departures`.
+
+**JSON output:**
+
+```json
+{
+  "type": "rejseplanen_arrivals",
+  "stop": "8600626",
+  "date": "2026-03-20",
+  "time": "08:00",
+  "arrivals": [
+    {
+      "name": "IC 456",
+      "line": "IC",
+      "origin": "Aarhus H",
+      "date": "2026-03-20",
+      "time": "11:23",
+      "rtDate": null,
+      "rtTime": null,
+      "track": "7",
+      "cancelled": false,
+      "stopId": "8600626",
+      "delayed": false,
+      "delayMinutes": 0,
+      "notes": []
+    }
+  ],
+  "count": 1
+}
+```
+
+The API returns `Arrival` array (or `ArrivalBoard.Arrival`). Same structure as departures but with `origin` instead of `direction`. Includes `delayed` (boolean), `delayMinutes` (computed from real-time vs scheduled), and `notes` (array of `{type, text}` objects). Note types: `"bike"` (from API key `FR`), `"accessibility"` (from API key `BE`), `"info"` (all others).
+
+---
+
+### `nearby` — Find nearby stops
+
+Find stops and stations near given coordinates.
+
+**API endpoint:** `GET /location.nearbystops`
+
+**Flags:**
+
+| Flag | Type | Required | Default | Description |
+|------|------|----------|---------|-------------|
+| `--lat` | number | yes | — | Latitude |
+| `--lon` | number | yes | — | Longitude |
+| `--radius` | number | no | 1000 | Search radius in meters |
+| `--max` | number | no | 10 | Max results |
+| `--format` | string | no | json | Output format |
+
+**API parameters mapping:**
+- `--lat` → `originCoordLat`
+- `--lon` → `originCoordLong`
+- `--radius` → `maxDist`
+- `--max` → `maxNo`
+
+**JSON output:**
+
+```json
+{
+  "type": "rejseplanen_nearby",
+  "lat": 55.672736,
+  "lon": 12.565558,
+  "radius": 1000,
+  "stops": [
+    {
+      "id": "8600626",
+      "name": "København H",
+      "lat": 55.672736,
+      "lon": 12.565558,
+      "dist": 120,
+      "type": "ST"
+    }
+  ],
+  "count": 1
+}
+```
+
+---
+
+### `disruptions` — Service alerts
+
+Show current service disruptions and travel alerts.
+
+**API endpoint:** `GET /himSearch`
+
+**Flags:**
+
+| Flag | Type | Required | Default | Description |
+|------|------|----------|---------|-------------|
+| `--stop` | string | no | — | Filter by stop ID |
+| `--line` | string | no | — | Filter by line ID |
+| `--date` | string | no | today | Date (YYYY-MM-DD) |
+| `--time` | string | no | now | Time (HH:MM) |
+| `--max` | number | no | 20 | Max results |
+| `--format` | string | no | json | Output format |
+
+**API parameters mapping:**
+- `--stop` → `stationId`
+- `--line` → `lineId`
+- `--date` → `dateB` and `dateE`
+- `--time` → `timeB` and `timeE`
+- `--max` → `maxNum`
+
+**JSON output:**
+
+```json
+{
+  "type": "rejseplanen_disruptions",
+  "date": "2026-03-18",
+  "disruptions": [
+    {
+      "id": "HIM_123",
+      "subject": "Sporarbejde København H - Ringsted",
+      "message": "Full disruption text...",
+      "priority": 2,
+      "startDate": "2026-03-18",
+      "startTime": "04:00",
+      "endDate": "2026-03-20",
+      "endTime": "23:59",
+      "affectedStops": ["København H", "Ringsted St."],
+      "affectedLines": ["IC", "Re"]
+    }
+  ],
+  "count": 1
+}
+```
+
+The API returns `him.message` array. Each message has `head` (subject), `text` (full message), `priority`, date/time range, and optional `affectedStops.StopLocation` and `affectedLines.Line` arrays.
+
+---
+
+## Error handling
+
+All errors are written to stderr as JSON and exit with code 1:
+
+```json
+{ "error": "REJSEPLANEN_ACCESS_ID environment variable is not set", "code": "AUTH_ERROR" }
+```
+
+Error codes:
+- `AUTH_ERROR` — Missing access ID
+- `MISSING_REQUIRED` — Missing required flag
+- `API_ERROR` — API request failed
+- `PARSE_ERROR` — Failed to parse API response
+
+---
+
+## API date/time format
+
+The API 2.0 uses ISO format for dates (`YYYY-MM-DD`) and `HH:MM:SS` for times. The CLI passes dates through as-is and truncates times to `HH:MM` in output.

--- a/skills/rejseplanen/cli/package.json
+++ b/skills/rejseplanen/cli/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "rejseplanen-cli",
+  "version": "1.0.0",
+  "description": "CLI for Danish public transport journey planning via the Rejseplanen API",
+  "type": "module",
+  "main": "src/cli.ts",
+  "bin": {
+    "rejseplanen": "src/cli.ts"
+  },
+  "scripts": {
+    "start": "bun run src/cli.ts",
+    "test": "bun test --timeout 30000",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@bunli/core": "latest",
+    "@bunli/utils": "latest",
+    "zod": "^3.23.0"
+  },
+  "devDependencies": {
+    "typescript": "^5.4.0",
+    "@types/bun": "latest"
+  }
+}

--- a/skills/rejseplanen/cli/src/cli.ts
+++ b/skills/rejseplanen/cli/src/cli.ts
@@ -1,0 +1,22 @@
+import { createCLI } from "@bunli/core"
+import { location } from "./commands/location.js"
+import { trip } from "./commands/trip.js"
+import { departures } from "./commands/departures.js"
+import { arrivals } from "./commands/arrivals.js"
+import { nearby } from "./commands/nearby.js"
+import { disruptions } from "./commands/disruptions.js"
+
+const cli = await createCLI({
+  name: "rejseplanen",
+  version: "1.0.0",
+  description: "CLI for Danish public transport journey planning via the Rejseplanen API",
+})
+
+cli.command(location)
+cli.command(trip)
+cli.command(departures)
+cli.command(arrivals)
+cli.command(nearby)
+cli.command(disruptions)
+
+await cli.run()

--- a/skills/rejseplanen/cli/src/commands/arrivals.ts
+++ b/skills/rejseplanen/cli/src/commands/arrivals.ts
@@ -1,0 +1,185 @@
+import { defineCommand, option } from "@bunli/core"
+import { z } from "zod"
+import { apiFetch, writeError, todayDate, nowTime, calcDelay, parseNotes } from "../helpers.js"
+import type { ParsedNote } from "../helpers.js"
+
+interface ProductInfo {
+  name: string
+  line?: string
+  catOutL?: string
+  displayNumber?: string
+}
+
+interface RawNote {
+  value?: string
+  key?: string
+  type?: string
+}
+
+interface ArrivalItem {
+  name: string
+  stop: string
+  stopid: string
+  stopExtId: string
+  line?: string
+  origin?: string
+  direction?: string
+  date: string
+  time: string
+  rtDate?: string
+  rtTime?: string
+  track?: string
+  rtTrack?: string
+  cancelled?: boolean
+  Product?: ProductInfo[] | ProductInfo
+  ProductAtStop?: ProductInfo
+  Notes?: { Note?: RawNote[] | RawNote }
+}
+
+interface ArrivalBoardResponse {
+  ArrivalBoard?: {
+    Arrival?: ArrivalItem[] | ArrivalItem
+  }
+  Arrival?: ArrivalItem[] | ArrivalItem
+}
+
+interface FormattedArrival {
+  name: string
+  line: string
+  origin: string
+  date: string
+  time: string
+  rtDate: string | null
+  rtTime: string | null
+  track: string | null
+  cancelled: boolean
+  stopId: string
+  delayed: boolean
+  delayMinutes: number
+  notes: ParsedNote[]
+}
+
+function getProduct(a: ArrivalItem): ProductInfo | undefined {
+  if (a.ProductAtStop) return a.ProductAtStop
+  if (a.Product) return Array.isArray(a.Product) ? a.Product[0] : a.Product
+  return undefined
+}
+
+function formatArrival(a: ArrivalItem): FormattedArrival {
+  const product = getProduct(a)
+  const delay = calcDelay(a.time, a.date, a.rtTime, a.rtDate)
+  const notes = parseNotes(a.Notes?.Note as any)
+  return {
+    name: a.name ?? product?.name ?? "",
+    line: a.line ?? product?.displayNumber ?? product?.line ?? product?.catOutL?.trim() ?? "",
+    origin: a.origin ?? a.direction ?? "",
+    date: a.date,
+    time: a.time.substring(0, 5),
+    rtDate: a.rtDate ?? null,
+    rtTime: a.rtTime?.substring(0, 5) ?? null,
+    track: a.rtTrack ?? a.track ?? null,
+    cancelled: a.cancelled ?? false,
+    stopId: a.stopExtId ?? a.stopid ?? "",
+    delayed: delay.delayed,
+    delayMinutes: delay.delayMinutes,
+    notes,
+  }
+}
+
+export const arrivals = defineCommand({
+  name: "arrivals",
+  description: "Show upcoming arrivals at a stop",
+  options: {
+    stop: option(z.string(), {
+      description: "Stop ID (required)",
+    }),
+    date: option(z.string().optional(), {
+      description: "Date YYYY-MM-DD (default: today)",
+    }),
+    time: option(z.string().optional(), {
+      description: "Time HH:MM (default: now)",
+    }),
+    duration: option(z.coerce.number().default(60), {
+      description: "Time window in minutes 0-1439 (default: 60)",
+    }),
+    max: option(z.coerce.number().default(20), {
+      description: "Max results (default: 20)",
+    }),
+    format: option(z.enum(["json", "table", "plain"]).default("json"), {
+      description: "Output format: json, table, plain",
+    }),
+  },
+  handler: async ({ flags, signal }) => {
+    if (signal.aborted) return
+
+    if (!flags.stop) {
+      writeError("--stop is required", "MISSING_REQUIRED")
+      process.exit(1)
+    }
+
+    const date = flags.date ?? todayDate()
+    const time = flags.time ?? nowTime()
+
+    try {
+      const params: Record<string, string> = {
+        id: flags.stop,
+        date,
+        time,
+        duration: String(flags.duration),
+        maxJourneys: String(flags.max),
+      }
+
+      const data = await apiFetch<ArrivalBoardResponse>("/arrivalBoard", params)
+
+      if (signal.aborted) return
+
+      const rawArrivals = data.ArrivalBoard?.Arrival ?? data.Arrival
+      const arrArray = rawArrivals
+        ? Array.isArray(rawArrivals) ? rawArrivals : [rawArrivals]
+        : []
+
+      const formattedArrs = arrArray.map(formatArrival)
+
+      const output = {
+        type: "rejseplanen_arrivals",
+        stop: flags.stop,
+        date,
+        time,
+        arrivals: formattedArrs,
+        count: formattedArrs.length,
+      }
+
+      if (flags.format === "json") {
+        console.log(JSON.stringify(output, null, 2))
+      } else if (flags.format === "table") {
+        console.log("Time   Name              Line      Origin                        Track")
+        for (const a of formattedArrs) {
+          const delayStr = a.delayed ? `(+${a.delayMinutes})` : ""
+          const rt = a.rtTime && a.rtTime !== a.time ? `(${a.rtTime})` : ""
+          const timeStr = `${a.time}${rt}${delayStr}`.padEnd(6)
+          const name = a.name.substring(0, 17).padEnd(18)
+          const line = a.line.substring(0, 9).padEnd(10)
+          const origin = a.origin.substring(0, 29).padEnd(30)
+          const track = a.track ?? ""
+          console.log(`${timeStr} ${name} ${line} ${origin} ${track}`)
+        }
+      } else {
+        for (const a of formattedArrs) {
+          const delay = a.delayed ? ` (+${a.delayMinutes} min)` : ""
+          const rt = a.rtTime ? ` (real-time: ${a.rtTime}${delay})` : ""
+          const track = a.track ? ` [Track ${a.track}]` : ""
+          const cancelled = a.cancelled ? " CANCELLED" : ""
+          console.log(`${a.time}${rt} ${a.name} from ${a.origin}${track}${cancelled}`)
+          if (a.notes.length > 0) {
+            for (const n of a.notes) {
+              console.log(`  [${n.type}] ${n.text}`)
+            }
+          }
+        }
+      }
+    } catch (err) {
+      writeError(err instanceof Error ? err.message : String(err), "API_ERROR")
+      process.exit(1)
+    }
+  },
+})

--- a/skills/rejseplanen/cli/src/commands/departures.ts
+++ b/skills/rejseplanen/cli/src/commands/departures.ts
@@ -1,0 +1,184 @@
+import { defineCommand, option } from "@bunli/core"
+import { z } from "zod"
+import { apiFetch, writeError, todayDate, nowTime, calcDelay, parseNotes } from "../helpers.js"
+import type { ParsedNote } from "../helpers.js"
+
+interface ProductInfo {
+  name: string
+  line?: string
+  catOutL?: string
+  displayNumber?: string
+}
+
+interface RawNote {
+  value?: string
+  key?: string
+  type?: string
+}
+
+interface DepartureItem {
+  name: string
+  stop: string
+  stopid: string
+  stopExtId: string
+  line?: string
+  direction: string
+  date: string
+  time: string
+  rtDate?: string
+  rtTime?: string
+  track?: string
+  rtTrack?: string
+  cancelled?: boolean
+  Product?: ProductInfo[] | ProductInfo
+  ProductAtStop?: ProductInfo
+  Notes?: { Note?: RawNote[] | RawNote }
+}
+
+interface DepartureBoardResponse {
+  DepartureBoard?: {
+    Departure?: DepartureItem[] | DepartureItem
+  }
+  Departure?: DepartureItem[] | DepartureItem
+}
+
+interface FormattedDeparture {
+  name: string
+  line: string
+  direction: string
+  date: string
+  time: string
+  rtDate: string | null
+  rtTime: string | null
+  track: string | null
+  cancelled: boolean
+  stopId: string
+  delayed: boolean
+  delayMinutes: number
+  notes: ParsedNote[]
+}
+
+function getProduct(d: DepartureItem): ProductInfo | undefined {
+  if (d.ProductAtStop) return d.ProductAtStop
+  if (d.Product) return Array.isArray(d.Product) ? d.Product[0] : d.Product
+  return undefined
+}
+
+function formatDeparture(d: DepartureItem): FormattedDeparture {
+  const product = getProduct(d)
+  const delay = calcDelay(d.time, d.date, d.rtTime, d.rtDate)
+  const notes = parseNotes(d.Notes?.Note as any)
+  return {
+    name: d.name ?? product?.name ?? "",
+    line: d.line ?? product?.displayNumber ?? product?.line ?? product?.catOutL?.trim() ?? "",
+    direction: d.direction ?? "",
+    date: d.date,
+    time: d.time.substring(0, 5),
+    rtDate: d.rtDate ?? null,
+    rtTime: d.rtTime?.substring(0, 5) ?? null,
+    track: d.rtTrack ?? d.track ?? null,
+    cancelled: d.cancelled ?? false,
+    stopId: d.stopExtId ?? d.stopid ?? "",
+    delayed: delay.delayed,
+    delayMinutes: delay.delayMinutes,
+    notes,
+  }
+}
+
+export const departures = defineCommand({
+  name: "departures",
+  description: "Show upcoming departures from a stop",
+  options: {
+    stop: option(z.string(), {
+      description: "Stop ID (required)",
+    }),
+    date: option(z.string().optional(), {
+      description: "Date YYYY-MM-DD (default: today)",
+    }),
+    time: option(z.string().optional(), {
+      description: "Time HH:MM (default: now)",
+    }),
+    duration: option(z.coerce.number().default(60), {
+      description: "Time window in minutes 0-1439 (default: 60)",
+    }),
+    max: option(z.coerce.number().default(20), {
+      description: "Max results (default: 20)",
+    }),
+    format: option(z.enum(["json", "table", "plain"]).default("json"), {
+      description: "Output format: json, table, plain",
+    }),
+  },
+  handler: async ({ flags, signal }) => {
+    if (signal.aborted) return
+
+    if (!flags.stop) {
+      writeError("--stop is required", "MISSING_REQUIRED")
+      process.exit(1)
+    }
+
+    const date = flags.date ?? todayDate()
+    const time = flags.time ?? nowTime()
+
+    try {
+      const params: Record<string, string> = {
+        id: flags.stop,
+        date,
+        time,
+        duration: String(flags.duration),
+        maxJourneys: String(flags.max),
+      }
+
+      const data = await apiFetch<DepartureBoardResponse>("/departureBoard", params)
+
+      if (signal.aborted) return
+
+      const rawDepartures = data.DepartureBoard?.Departure ?? data.Departure
+      const depArray = rawDepartures
+        ? Array.isArray(rawDepartures) ? rawDepartures : [rawDepartures]
+        : []
+
+      const formattedDeps = depArray.map(formatDeparture)
+
+      const output = {
+        type: "rejseplanen_departures",
+        stop: flags.stop,
+        date,
+        time,
+        departures: formattedDeps,
+        count: formattedDeps.length,
+      }
+
+      if (flags.format === "json") {
+        console.log(JSON.stringify(output, null, 2))
+      } else if (flags.format === "table") {
+        console.log("Time   Name              Line      Direction                     Track")
+        for (const d of formattedDeps) {
+          const delayStr = d.delayed ? `(+${d.delayMinutes})` : ""
+          const rt = d.rtTime && d.rtTime !== d.time ? `(${d.rtTime})` : ""
+          const timeStr = `${d.time}${rt}${delayStr}`.padEnd(6)
+          const name = d.name.substring(0, 17).padEnd(18)
+          const line = d.line.substring(0, 9).padEnd(10)
+          const dir = d.direction.substring(0, 29).padEnd(30)
+          const track = d.track ?? ""
+          console.log(`${timeStr} ${name} ${line} ${dir} ${track}`)
+        }
+      } else {
+        for (const d of formattedDeps) {
+          const delay = d.delayed ? ` (+${d.delayMinutes} min)` : ""
+          const rt = d.rtTime ? ` (real-time: ${d.rtTime}${delay})` : ""
+          const track = d.track ? ` [Track ${d.track}]` : ""
+          const cancelled = d.cancelled ? " CANCELLED" : ""
+          console.log(`${d.time}${rt} ${d.name} → ${d.direction}${track}${cancelled}`)
+          if (d.notes.length > 0) {
+            for (const n of d.notes) {
+              console.log(`  [${n.type}] ${n.text}`)
+            }
+          }
+        }
+      }
+    } catch (err) {
+      writeError(err instanceof Error ? err.message : String(err), "API_ERROR")
+      process.exit(1)
+    }
+  },
+})

--- a/skills/rejseplanen/cli/src/commands/disruptions.ts
+++ b/skills/rejseplanen/cli/src/commands/disruptions.ts
@@ -1,0 +1,168 @@
+import { defineCommand, option } from "@bunli/core"
+import { z } from "zod"
+import { apiFetch, writeError, todayDate, nowTime } from "../helpers.js"
+
+interface StopLocation {
+  name: string
+  extId: string
+}
+
+interface Line {
+  name: string
+  lineId: string
+}
+
+interface HimMessage {
+  id: string
+  act: boolean
+  head: string
+  text: string
+  lead?: string
+  priority: number
+  sDate: string
+  sTime: string
+  eDate: string
+  eTime: string
+  affectedStops?: {
+    StopLocation: StopLocation[] | StopLocation
+  }
+  affectedLines?: {
+    Line: Line[] | Line
+  }
+}
+
+interface HimResponse {
+  him?: {
+    message?: HimMessage[] | HimMessage
+  }
+}
+
+interface FormattedDisruption {
+  id: string
+  subject: string
+  message: string
+  priority: number
+  startDate: string
+  startTime: string
+  endDate: string
+  endTime: string
+  affectedStops: string[]
+  affectedLines: string[]
+}
+
+function normalizeArray<T>(items: T[] | T | undefined): T[] {
+  if (!items) return []
+  return Array.isArray(items) ? items : [items]
+}
+
+function formatDisruption(msg: HimMessage): FormattedDisruption {
+  const stops = normalizeArray(msg.affectedStops?.StopLocation).map(s => s.name)
+  const lines = normalizeArray(msg.affectedLines?.Line).map(l => l.name)
+
+  return {
+    id: msg.id,
+    subject: msg.head,
+    message: msg.text,
+    priority: msg.priority,
+    startDate: msg.sDate,
+    startTime: msg.sTime.substring(0, 5),
+    endDate: msg.eDate,
+    endTime: msg.eTime.substring(0, 5),
+    affectedStops: stops,
+    affectedLines: lines,
+  }
+}
+
+export const disruptions = defineCommand({
+  name: "disruptions",
+  description: "Show current service disruptions and alerts",
+  options: {
+    stop: option(z.string().optional(), {
+      description: "Stop ID to filter by",
+    }),
+    line: option(z.string().optional(), {
+      description: "Line ID to filter by",
+    }),
+    date: option(z.string().optional(), {
+      description: "Date YYYY-MM-DD (default: today)",
+    }),
+    time: option(z.string().optional(), {
+      description: "Time HH:MM (default: now)",
+    }),
+    max: option(z.coerce.number().default(20), {
+      description: "Max results (default: 20)",
+    }),
+    format: option(z.enum(["json", "table", "plain"]).default("json"), {
+      description: "Output format: json, table, plain",
+    }),
+  },
+  handler: async ({ flags, signal }) => {
+    if (signal.aborted) return
+
+    const date = flags.date ?? todayDate()
+    const time = flags.time ?? nowTime()
+
+    try {
+      const params: Record<string, string> = {
+        dateB: date,
+        dateE: date,
+        timeB: time,
+        timeE: time,
+        maxNum: String(flags.max),
+      }
+
+      if (flags.stop) {
+        params.stationId = flags.stop
+      }
+      if (flags.line) {
+        params.lineId = flags.line
+      }
+
+      const data = await apiFetch<HimResponse>("/himSearch", params)
+
+      if (signal.aborted) return
+
+      const rawMessages = data.him?.message
+      const msgArray = rawMessages
+        ? Array.isArray(rawMessages) ? rawMessages : [rawMessages]
+        : []
+
+      const formatted = msgArray.map(formatDisruption)
+
+      const output = {
+        type: "rejseplanen_disruptions",
+        date,
+        disruptions: formatted,
+        count: formatted.length,
+      }
+
+      if (flags.format === "json") {
+        console.log(JSON.stringify(output, null, 2))
+      } else if (flags.format === "table") {
+        console.log("Prio  Subject                                    Start       End")
+        for (const d of formatted) {
+          const prio = String(d.priority).padEnd(5)
+          const subject = d.subject.substring(0, 42).padEnd(43)
+          const start = `${d.startDate} ${d.startTime}`.padEnd(12)
+          const end = `${d.endDate} ${d.endTime}`
+          console.log(`${prio} ${subject} ${start} ${end}`)
+        }
+      } else {
+        for (const d of formatted) {
+          console.log(`[Prio ${d.priority}] ${d.subject}`)
+          console.log(`  ${d.startDate} ${d.startTime} → ${d.endDate} ${d.endTime}`)
+          console.log(`  ${d.message}`)
+          if (d.affectedStops.length > 0) {
+            console.log(`  Stops: ${d.affectedStops.join(", ")}`)
+          }
+          if (d.affectedLines.length > 0) {
+            console.log(`  Lines: ${d.affectedLines.join(", ")}`)
+          }
+        }
+      }
+    } catch (err) {
+      writeError(err instanceof Error ? err.message : String(err), "API_ERROR")
+      process.exit(1)
+    }
+  },
+})

--- a/skills/rejseplanen/cli/src/commands/location.ts
+++ b/skills/rejseplanen/cli/src/commands/location.ts
@@ -1,0 +1,126 @@
+import { defineCommand, option } from "@bunli/core"
+import { z } from "zod"
+import { apiFetch, writeError } from "../helpers.js"
+
+interface StopLocation {
+  name: string
+  extId: string
+  lon: number
+  lat: number
+  weight: number
+  id: string
+}
+
+interface CoordLocation {
+  name: string
+  lon: number
+  lat: number
+  type: string
+  id?: string
+}
+
+interface LocationResponse {
+  stopLocationOrCoordLocation?: Array<{
+    StopLocation?: StopLocation
+    CoordLocation?: CoordLocation
+  }>
+}
+
+interface FormattedLocation {
+  id: string
+  name: string
+  lat: number
+  lon: number
+  type: string
+}
+
+export const location = defineCommand({
+  name: "location",
+  description: "Search for stops, stations, and addresses",
+  options: {
+    query: option(z.string(), {
+      description: "Search string (required)",
+    }),
+    max: option(z.coerce.number().default(10), {
+      description: "Max results (default: 10)",
+    }),
+    type: option(z.enum(["S", "A", "P", "ALL"]).default("ALL"), {
+      description: "Filter: S=stop, A=address, P=POI, ALL=all",
+    }),
+    format: option(z.enum(["json", "table", "plain"]).default("json"), {
+      description: "Output format: json, table, plain",
+    }),
+  },
+  handler: async ({ flags, signal }) => {
+    if (signal.aborted) return
+
+    if (!flags.query) {
+      writeError("--query is required", "MISSING_REQUIRED")
+      process.exit(1)
+    }
+
+    try {
+      const params: Record<string, string> = {
+        input: flags.query,
+        maxNo: String(flags.max),
+      }
+      if (flags.type !== "ALL") {
+        params.type = flags.type
+      }
+
+      const data = await apiFetch<LocationResponse>("/location.name", params)
+
+      if (signal.aborted) return
+
+      const locations: FormattedLocation[] = (data.stopLocationOrCoordLocation ?? []).map((entry) => {
+        if (entry.StopLocation) {
+          const s = entry.StopLocation
+          return {
+            id: s.extId ?? s.id,
+            name: s.name,
+            lat: s.lat,
+            lon: s.lon,
+            type: "ST",
+          }
+        }
+        const c = entry.CoordLocation!
+        return {
+          id: c.id ?? "",
+          name: c.name,
+          lat: c.lat,
+          lon: c.lon,
+          type: c.type === "ADR" ? "ADR" : "POI",
+        }
+      })
+
+      const output = {
+        type: "rejseplanen_location",
+        query: flags.query,
+        locations,
+        count: locations.length,
+      }
+
+      if (flags.format === "json") {
+        console.log(JSON.stringify(output, null, 2))
+      } else if (flags.format === "table") {
+        console.log("ID              Name                                      Type  Lat        Lon")
+        for (const l of locations) {
+          const id = l.id.padEnd(15)
+          const name = l.name.substring(0, 40).padEnd(42)
+          const type = l.type.padEnd(5)
+          console.log(`${id} ${name} ${type} ${l.lat.toFixed(6)}  ${l.lon.toFixed(6)}`)
+        }
+      } else {
+        for (const l of locations) {
+          console.log(`${l.name} (${l.type})`)
+          console.log(`  ID: ${l.id}`)
+          console.log(`  Coordinates: ${l.lat.toFixed(6)}, ${l.lon.toFixed(6)}`)
+          console.log("")
+        }
+      }
+    } catch (err) {
+      writeError(err instanceof Error ? err.message : String(err), "API_ERROR")
+      process.exit(1)
+    }
+  },
+})

--- a/skills/rejseplanen/cli/src/commands/nearby.ts
+++ b/skills/rejseplanen/cli/src/commands/nearby.ts
@@ -1,0 +1,141 @@
+import { defineCommand, option } from "@bunli/core"
+import { z } from "zod"
+import { apiFetch, writeError } from "../helpers.js"
+
+interface StopLocation {
+  name: string
+  extId: string
+  lon: number
+  lat: number
+  weight: number
+  id: string
+  dist: number
+  type?: string
+}
+
+interface CoordLocation {
+  name: string
+  lon: number
+  lat: number
+  type: string
+  id?: string
+  dist?: number
+}
+
+interface NearbyResponse {
+  stopLocationOrCoordLocation?: Array<{
+    StopLocation?: StopLocation
+    CoordLocation?: CoordLocation
+  }>
+}
+
+interface FormattedStop {
+  id: string
+  name: string
+  lat: number
+  lon: number
+  dist: number
+  type: string
+}
+
+export const nearby = defineCommand({
+  name: "nearby",
+  description: "Find nearby stops and stations",
+  options: {
+    lat: option(z.coerce.number(), {
+      description: "Latitude (required)",
+    }),
+    lon: option(z.coerce.number(), {
+      description: "Longitude (required)",
+    }),
+    radius: option(z.coerce.number().default(1000), {
+      description: "Search radius in meters (default: 1000)",
+    }),
+    max: option(z.coerce.number().default(10), {
+      description: "Max results (default: 10)",
+    }),
+    format: option(z.enum(["json", "table", "plain"]).default("json"), {
+      description: "Output format: json, table, plain",
+    }),
+  },
+  handler: async ({ flags, signal }) => {
+    if (signal.aborted) return
+
+    if (isNaN(flags.lat)) {
+      writeError("--lat is required", "MISSING_REQUIRED")
+      process.exit(1)
+    }
+
+    if (isNaN(flags.lon)) {
+      writeError("--lon is required", "MISSING_REQUIRED")
+      process.exit(1)
+    }
+
+    try {
+      const params: Record<string, string> = {
+        originCoordLat: String(flags.lat),
+        originCoordLong: String(flags.lon),
+        maxDist: String(flags.radius),
+        maxNo: String(flags.max),
+      }
+
+      const data = await apiFetch<NearbyResponse>("/location.nearbystops", params)
+
+      if (signal.aborted) return
+
+      const stops: FormattedStop[] = (data.stopLocationOrCoordLocation ?? []).map((entry) => {
+        if (entry.StopLocation) {
+          const s = entry.StopLocation
+          return {
+            id: s.extId ?? s.id,
+            name: s.name,
+            lat: s.lat,
+            lon: s.lon,
+            dist: s.dist ?? 0,
+            type: "ST",
+          }
+        }
+        const c = entry.CoordLocation!
+        return {
+          id: c.id ?? "",
+          name: c.name,
+          lat: c.lat,
+          lon: c.lon,
+          dist: c.dist ?? 0,
+          type: c.type === "ADR" ? "ADR" : "POI",
+        }
+      })
+
+      const output = {
+        type: "rejseplanen_nearby",
+        lat: flags.lat,
+        lon: flags.lon,
+        radius: flags.radius,
+        stops,
+        count: stops.length,
+      }
+
+      if (flags.format === "json") {
+        console.log(JSON.stringify(output, null, 2))
+      } else if (flags.format === "table") {
+        console.log("Name                            ID              Dist    Type")
+        for (const s of stops) {
+          const name = s.name.substring(0, 30).padEnd(32)
+          const id = s.id.padEnd(15)
+          const dist = `${s.dist}m`.padEnd(8)
+          console.log(`${name} ${id} ${dist} ${s.type}`)
+        }
+      } else {
+        for (const s of stops) {
+          console.log(`${s.name} (${s.type})`)
+          console.log(`  ID: ${s.id}  Distance: ${s.dist}m`)
+          console.log(`  Coordinates: ${s.lat.toFixed(6)}, ${s.lon.toFixed(6)}`)
+          console.log("")
+        }
+      }
+    } catch (err) {
+      writeError(err instanceof Error ? err.message : String(err), "API_ERROR")
+      process.exit(1)
+    }
+  },
+})

--- a/skills/rejseplanen/cli/src/commands/trip.ts
+++ b/skills/rejseplanen/cli/src/commands/trip.ts
@@ -1,0 +1,461 @@
+import { defineCommand, option } from "@bunli/core"
+import { z } from "zod"
+import { apiFetch, writeError, todayDate, nowTime, calcDelay, parseNotes } from "../helpers.js"
+import type { ParsedNote } from "../helpers.js"
+
+interface TripLegOriginDest {
+  name: string
+  type: string
+  extId?: string
+  date: string
+  time: string
+  rtDate?: string
+  rtTime?: string
+  track?: string
+}
+
+interface TripProduct {
+  name: string
+  line?: string
+  catOutL?: string
+}
+
+interface JourneyDetailRef {
+  ref: string
+}
+
+interface TripLeg {
+  Origin: TripLegOriginDest
+  Destination: TripLegOriginDest
+  Product?: TripProduct[] | TripProduct
+  JourneyDetailRef?: JourneyDetailRef
+  direction?: string
+  type: string
+  cancelled?: boolean
+  name?: string
+  Notes?: { Note?: RawNote[] | RawNote }
+}
+
+interface RawNote {
+  value?: string
+  key?: string
+  type?: string
+}
+
+interface FareParam {
+  name: string
+  value: string
+}
+
+interface FareItem {
+  price: number
+  cur: string
+  param: FareParam[]
+}
+
+interface FareSetItem {
+  fareSetDescription?: string
+  fareItem: FareItem[]
+}
+
+interface TariffResult {
+  fareSetItem?: FareSetItem[]
+}
+
+interface TripItem {
+  LegList: {
+    Leg: TripLeg[] | TripLeg
+  }
+  TariffResult?: TariffResult
+}
+
+interface TripResponse {
+  Trip?: TripItem[] | TripItem
+  scrB?: string
+  scrF?: string
+}
+
+interface FormattedFare {
+  passenger: string
+  product: string
+  class: string
+  price: number
+  currency: string
+}
+
+const PASSENGER_NAMES: Record<string, string> = {
+  A: "Adult",
+  C: "Child",
+  P: "Pensioner",
+  Y: "Youth",
+  H: "Halvpris",
+}
+
+function extractFares(tariff: TariffResult | undefined): FormattedFare[] {
+  if (!tariff?.fareSetItem) return []
+  const fares: FormattedFare[] = []
+  // Only take the first fareSet (single tickets), skip commuter passes
+  const fareSet = tariff.fareSetItem[0]
+  if (!fareSet) return []
+  for (const item of fareSet.fareItem) {
+    const params: Record<string, string> = {}
+    for (const p of item.param) {
+      params[p.name] = p.value
+    }
+    // Only include standard class fares for clarity
+    if (params.class !== "S") continue
+    const psgCode = params.psg ?? "?"
+    fares.push({
+      passenger: PASSENGER_NAMES[psgCode] ?? psgCode,
+      product: params.prod_name ?? params.trf_name ?? "Ticket",
+      class: "Standard",
+      price: item.price / 100,
+      currency: item.cur,
+    })
+  }
+  return fares
+}
+
+interface LocationResponse {
+  stopLocationOrCoordLocation?: Array<{
+    StopLocation?: { extId: string; name: string; id: string }
+    CoordLocation?: { id?: string; name: string }
+  }>
+}
+
+/** Resolve a name to a stop extId via the location API */
+async function resolveStopId(name: string): Promise<string> {
+  const data = await apiFetch<LocationResponse>("/location.name", {
+    input: name,
+    maxNo: "1",
+  })
+  const loc = data.stopLocationOrCoordLocation?.[0]?.StopLocation
+  if (!loc) {
+    throw new Error(`Could not find stop matching "${name}"`)
+  }
+  return loc.extId
+}
+
+interface JourneyDetailStop {
+  name: string
+  extId?: string
+  arrTime?: string | null
+  depTime?: string | null
+  arrDate?: string | null
+  depDate?: string | null
+  track?: string
+  routeIdx?: number
+}
+
+interface JourneyDetailResponse {
+  Stops?: {
+    Stop?: JourneyDetailStop[] | JourneyDetailStop
+  }
+  JourneyDetail?: {
+    Stops?: {
+      Stop?: JourneyDetailStop[] | JourneyDetailStop
+    }
+  }
+}
+
+interface FormattedStop {
+  name: string
+  arrival: string | null
+  departure: string | null
+}
+
+async function fetchJourneyDetail(ref: string): Promise<FormattedStop[]> {
+  const data = await apiFetch<JourneyDetailResponse>("/journeyDetail", { id: ref })
+  const rawStops = data.Stops?.Stop ?? data.JourneyDetail?.Stops?.Stop
+  if (!rawStops) return []
+  const stops = Array.isArray(rawStops) ? rawStops : [rawStops]
+  return stops.map((s) => ({
+    name: s.name,
+    arrival: s.arrTime?.substring(0, 5) ?? null,
+    departure: s.depTime?.substring(0, 5) ?? null,
+  }))
+}
+
+interface FormattedLeg {
+  name: string
+  type: string
+  origin: string
+  destination: string
+  departure: string
+  arrival: string
+  track: string | null
+  direction: string | null
+  cancelled: boolean
+  rtDeparture: string | null
+  rtArrival: string | null
+  delayed: boolean
+  delayMinutes: number
+  notes: ParsedNote[]
+  stops?: FormattedStop[]
+}
+
+interface FormattedTrip {
+  origin: string
+  destination: string
+  departure: string
+  arrival: string
+  duration: string
+  changes: number
+  legs: FormattedLeg[]
+  fares?: FormattedFare[]
+}
+
+function isStopId(value: string): boolean {
+  return /^\d+$/.test(value)
+}
+
+function calcDuration(depTime: string, arrTime: string, depDate: string, arrDate: string): string {
+  const [dh, dm] = depTime.split(":").map(Number)
+  const [ah, am] = arrTime.split(":").map(Number)
+
+  let depMinutes = dh * 60 + dm
+  let arrMinutes = ah * 60 + am
+
+  // Handle overnight trips
+  if (depDate !== arrDate || arrMinutes < depMinutes) {
+    arrMinutes += 24 * 60
+  }
+
+  const diff = arrMinutes - depMinutes
+  const hours = Math.floor(diff / 60)
+  const minutes = diff % 60
+  return `${hours}:${String(minutes).padStart(2, "0")}`
+}
+
+function formatLeg(leg: TripLeg): FormattedLeg {
+  const product = Array.isArray(leg.Product) ? leg.Product[0] : leg.Product
+  const isWalk = leg.type === "WALK" || leg.type === "TRSF"
+  const depDelay = calcDelay(leg.Origin.time, leg.Origin.date, leg.Origin.rtTime, leg.Origin.rtDate)
+  const notes = parseNotes(leg.Notes?.Note as any)
+  return {
+    name: isWalk ? "Walk" : (product?.name ?? leg.name ?? "Unknown"),
+    type: isWalk ? "WALK" : (product?.catOutL?.trim() ?? leg.type ?? ""),
+    origin: leg.Origin.name,
+    destination: leg.Destination.name,
+    departure: leg.Origin.time.substring(0, 5),
+    arrival: leg.Destination.time.substring(0, 5),
+    track: leg.Origin.track ?? null,
+    direction: leg.direction ?? null,
+    cancelled: leg.cancelled ?? false,
+    rtDeparture: leg.Origin.rtTime?.substring(0, 5) ?? null,
+    rtArrival: leg.Destination.rtTime?.substring(0, 5) ?? null,
+    delayed: depDelay.delayed,
+    delayMinutes: depDelay.delayMinutes,
+    notes,
+  }
+}
+
+export const trip = defineCommand({
+  name: "trip",
+  description: "Plan a journey between two locations",
+  options: {
+    origin: option(z.string(), {
+      description: "Origin stop ID or name (required)",
+    }),
+    destination: option(z.string(), {
+      description: "Destination stop ID or name (required)",
+    }),
+    via: option(z.string().optional(), {
+      description: "Via stop ID or name",
+    }),
+    date: option(z.string().optional(), {
+      description: "Travel date YYYY-MM-DD (default: today)",
+    }),
+    time: option(z.string().optional(), {
+      description: "Travel time HH:MM (default: now)",
+    }),
+    "arrive-by": option(z.coerce.boolean().default(false), {
+      description: "Search by arrival time",
+    }),
+    results: option(z.coerce.number().default(5), {
+      description: "Number of trips 1-6 (default: 5)",
+    }),
+    "no-fares": option(z.coerce.boolean().default(false), {
+      description: "Exclude fare/pricing information",
+    }),
+    stops: option(z.coerce.boolean().default(false), {
+      description: "Show intermediate stops for each leg",
+    }),
+    scroll: option(z.string().optional(), {
+      description: "Scroll token for pagination (scrollEarlier/scrollLater)",
+    }),
+    format: option(z.enum(["json", "table", "plain"]).default("json"), {
+      description: "Output format: json, table, plain",
+    }),
+  },
+  handler: async ({ flags, signal }) => {
+    if (signal.aborted) return
+
+    if (!flags.origin) {
+      writeError("--origin is required", "MISSING_REQUIRED")
+      process.exit(1)
+    }
+    if (!flags.destination) {
+      writeError("--destination is required", "MISSING_REQUIRED")
+      process.exit(1)
+    }
+
+    const date = flags.date ?? todayDate()
+    const time = flags.time ?? nowTime()
+
+    try {
+      const params: Record<string, string> = {
+        date,
+        time,
+        numF: String(flags.results),
+      }
+
+      // Resolve names to stop IDs if needed
+      const originId = isStopId(flags.origin) ? flags.origin : await resolveStopId(flags.origin)
+      const destId = isStopId(flags.destination) ? flags.destination : await resolveStopId(flags.destination)
+
+      params.originExtId = originId
+      params.destExtId = destId
+
+      if (flags.via) {
+        const viaId = isStopId(flags.via) ? flags.via : await resolveStopId(flags.via)
+        params.viaExtId = viaId
+      }
+
+      if (flags["arrive-by"]) {
+        params.searchForArrival = "1"
+      }
+
+      if (flags.scroll) {
+        params.ctx = flags.scroll
+      }
+
+      const data = await apiFetch<TripResponse>("/trip", params)
+
+      if (signal.aborted) return
+
+      const rawTrips = data.Trip
+        ? Array.isArray(data.Trip) ? data.Trip : [data.Trip]
+        : []
+
+      const trips: FormattedTrip[] = rawTrips.map((t) => {
+        const legs = Array.isArray(t.LegList.Leg) ? t.LegList.Leg : [t.LegList.Leg]
+        const formattedLegs = legs.map(formatLeg)
+        const firstLeg = formattedLegs[0]
+        const lastLeg = formattedLegs[formattedLegs.length - 1]
+        const transitLegs = formattedLegs.filter((l) => l.type !== "WALK")
+
+        const result: FormattedTrip = {
+          origin: firstLeg.origin,
+          destination: lastLeg.destination,
+          departure: firstLeg.departure,
+          arrival: lastLeg.arrival,
+          duration: calcDuration(
+            firstLeg.departure,
+            lastLeg.arrival,
+            legs[0].Origin.date,
+            legs[legs.length - 1].Destination.date,
+          ),
+          changes: Math.max(0, transitLegs.length - 1),
+          legs: formattedLegs,
+        }
+
+        if (!flags["no-fares"]) {
+          result.fares = extractFares(t.TariffResult)
+        }
+
+        return result
+      })
+
+      // Fetch journey details for --stops
+      if (flags.stops) {
+        const fetches: Promise<void>[] = []
+        for (const t of trips) {
+          for (let i = 0; i < t.legs.length; i++) {
+            const leg = t.legs[i]
+            // Only fetch for non-walk legs that have a JourneyDetailRef
+            if (leg.type !== "WALK") {
+              const tripIdx = trips.indexOf(t)
+              const rawTrip = rawTrips[tripIdx]
+              const rawLegs = Array.isArray(rawTrip.LegList.Leg) ? rawTrip.LegList.Leg : [rawTrip.LegList.Leg]
+              const rawL = rawLegs[i]
+              if (rawL?.JourneyDetailRef?.ref) {
+                const ref = rawL.JourneyDetailRef.ref
+                fetches.push(
+                  fetchJourneyDetail(ref).then((stops) => {
+                    leg.stops = stops
+                  })
+                )
+              }
+            }
+          }
+        }
+        await Promise.all(fetches)
+      }
+
+      const output: Record<string, unknown> = {
+        type: "rejseplanen_trip",
+        origin: flags.origin,
+        destination: flags.destination,
+        date,
+        time,
+        trips,
+        tripCount: trips.length,
+      }
+
+      if (flags.via) {
+        output.via = flags.via
+      }
+
+      if (data.scrB) {
+        output.scrollEarlier = data.scrB
+      }
+      if (data.scrF) {
+        output.scrollLater = data.scrF
+      }
+
+      if (flags.format === "json") {
+        console.log(JSON.stringify(output, null, 2))
+      } else if (flags.format === "table") {
+        console.log("Dep    Arr    Duration  Changes  Route")
+        for (const t of trips) {
+          const route = t.legs.map((l) => l.name).join(" → ")
+          console.log(`${t.departure}  ${t.arrival}  ${t.duration.padEnd(9)} ${String(t.changes).padEnd(8)} ${route}`)
+        }
+      } else {
+        for (const t of trips) {
+          console.log(`${t.origin} → ${t.destination}`)
+          console.log(`  Departure: ${t.departure}  Arrival: ${t.arrival}  Duration: ${t.duration}  Changes: ${t.changes}`)
+          for (const l of t.legs) {
+            const delay = l.delayed ? ` (+${l.delayMinutes} min)` : ""
+            const rt = l.rtDeparture ? ` (real-time: ${l.rtDeparture}${delay})` : ""
+            console.log(`  - ${l.name} ${l.departure}→${l.arrival}${rt} ${l.origin} → ${l.destination}`)
+            if (l.notes.length > 0) {
+              for (const n of l.notes) {
+                console.log(`    [${n.type}] ${n.text}`)
+              }
+            }
+            if (l.stops && l.stops.length > 0) {
+              console.log("    Stops:")
+              for (const s of l.stops) {
+                const arr = s.arrival ?? "     "
+                const dep = s.departure ?? "     "
+                console.log(`      ${arr} ${dep} ${s.name}`)
+              }
+            }
+          }
+          if (t.fares && t.fares.length > 0) {
+            console.log("  Fares:")
+            for (const f of t.fares) {
+              console.log(`    ${f.passenger}: ${f.price.toFixed(2)} ${f.currency} (${f.product})`)
+            }
+          }
+          console.log("")
+        }
+      }
+    } catch (err) {
+      writeError(err instanceof Error ? err.message : String(err), "API_ERROR")
+      process.exit(1)
+    }
+  },
+})

--- a/skills/rejseplanen/cli/src/helpers.ts
+++ b/skills/rejseplanen/cli/src/helpers.ts
@@ -1,0 +1,119 @@
+export const BASE_URL = "https://www.rejseplanen.dk/api"
+
+function getAccessId(): string {
+  const id = process.env.REJSEPLANEN_ACCESS_ID
+  if (!id) {
+    throw new Error("REJSEPLANEN_ACCESS_ID environment variable is not set. Get an access ID from Rejseplanen: https://help.rejseplanen.dk/hc/da/articles/214174465-Adgang-til-Rejseplanens-API")
+  }
+  return id
+}
+
+export async function apiFetch<T>(path: string, params?: Record<string, string>): Promise<T> {
+  const accessId = getAccessId()
+  const url = new URL(`${BASE_URL}${path}`)
+  url.searchParams.set("accessId", accessId)
+  url.searchParams.set("format", "json")
+  if (params) {
+    for (const [key, value] of Object.entries(params)) {
+      url.searchParams.set(key, value)
+    }
+  }
+
+  const maxRetries = 6
+  let delay = 500
+  for (let attempt = 0; attempt <= maxRetries; attempt++) {
+    const response = await fetch(url.toString())
+    if (response.status === 429 || response.status >= 500) {
+      if (attempt === maxRetries) {
+        throw new Error(`API request failed: ${response.status} ${response.statusText}`)
+      }
+      const jitter = Math.floor(Math.random() * 500)
+      await new Promise((resolve) => setTimeout(resolve, delay + jitter))
+      delay = Math.min(delay * 2, 5000)
+      continue
+    }
+    if (!response.ok) {
+      throw new Error(`API request failed: ${response.status} ${response.statusText}`)
+    }
+    return response.json() as Promise<T>
+  }
+  throw new Error("API request failed after max retries")
+}
+
+export function writeError(error: string, code: string): void {
+  process.stderr.write(JSON.stringify({ error, code }) + "\n")
+}
+
+/** Get today's date as YYYY-MM-DD */
+export function todayDate(): string {
+  const now = new Date()
+  const y = now.getFullYear()
+  const m = String(now.getMonth() + 1).padStart(2, "0")
+  const d = String(now.getDate()).padStart(2, "0")
+  return `${y}-${m}-${d}`
+}
+
+/** Get current time as HH:MM */
+export function nowTime(): string {
+  const now = new Date()
+  const h = String(now.getHours()).padStart(2, "0")
+  const m = String(now.getMinutes()).padStart(2, "0")
+  return `${h}:${m}`
+}
+
+/** Calculate delay between scheduled and real-time */
+export function calcDelay(
+  scheduledTime: string,
+  scheduledDate: string,
+  rtTime?: string | null,
+  rtDate?: string | null,
+): { delayed: boolean; delayMinutes: number } {
+  if (!rtTime) return { delayed: false, delayMinutes: 0 }
+
+  const [sh, sm] = scheduledTime.split(":").map(Number)
+  const [rh, rm] = rtTime.split(":").map(Number)
+
+  let scheduledMin = sh * 60 + sm
+  let rtMin = rh * 60 + rm
+
+  // Handle day boundary
+  if (rtDate && rtDate !== scheduledDate) {
+    rtMin += 24 * 60
+  } else if (rtMin < scheduledMin - 720) {
+    // Next day wrap (e.g., scheduled 23:50, rt 00:02)
+    rtMin += 24 * 60
+  }
+
+  const diff = rtMin - scheduledMin
+  return { delayed: diff > 0, delayMinutes: Math.max(0, diff) }
+}
+
+export interface ParsedNote {
+  type: "bike" | "accessibility" | "info"
+  text: string
+}
+
+interface RawNote {
+  value?: string
+  key?: string
+  type?: string
+  routeIdxFrom?: number
+  routeIdxTo?: number
+}
+
+/** Parse Notes array from API into typed notes */
+export function parseNotes(notes?: RawNote[] | RawNote | null): ParsedNote[] {
+  if (!notes) return []
+  const arr = Array.isArray(notes) ? notes : [notes]
+  const result: ParsedNote[] = []
+  for (const note of arr) {
+    if (!note.value) continue
+    // Filter out internal/technical notes
+    if (note.type === "I") continue
+    let type: ParsedNote["type"] = "info"
+    if (note.key === "FR") type = "bike"
+    else if (note.key === "BE") type = "accessibility"
+    result.push({ type, text: note.value })
+  }
+  return result
+}

--- a/skills/rejseplanen/cli/tests/commands/arrivals.test.ts
+++ b/skills/rejseplanen/cli/tests/commands/arrivals.test.ts
@@ -1,0 +1,104 @@
+import { describe, test, expect } from "bun:test"
+import { runCLI, parseJSON, hasAccessId } from "../helpers"
+
+interface ArrivalItem {
+  name: string
+  line: string
+  origin: string
+  date: string
+  time: string
+  rtDate: string | null
+  rtTime: string | null
+  track: string | null
+  cancelled: boolean
+  stopId: string
+  delayed: boolean
+  delayMinutes: number
+  notes: Array<{ type: string; text: string }>
+}
+
+interface ArrivalsResponse {
+  type: string
+  stop: string
+  date: string
+  time: string
+  arrivals: ArrivalItem[]
+  count: number
+}
+
+const SKIP = !hasAccessId()
+
+// København H stop ID
+const KOEBENHAVN_H = "8600626"
+
+describe("arrivals command", () => {
+  test("missing --stop exits with error", async () => {
+    const result = await runCLI(["arrivals"])
+    expect(result.exitCode).toBe(1)
+    expect(result.stderr.toLowerCase()).toContain("error")
+  })
+
+  test("arrivals returns correct shape", async () => {
+    if (SKIP) {
+      console.log("Skipping: REJSEPLANEN_ACCESS_ID not set")
+      return
+    }
+    const result = await runCLI(["arrivals", "--stop", KOEBENHAVN_H, "--max", "3"])
+    const data = parseJSON<ArrivalsResponse>(result)
+
+    expect(data.type).toBe("rejseplanen_arrivals")
+    expect(data.stop).toBe(KOEBENHAVN_H)
+    expect(Array.isArray(data.arrivals)).toBe(true)
+    expect(data.count).toBe(data.arrivals.length)
+    expect(data.count).toBeGreaterThan(0)
+  })
+
+  test("arrival items have all expected fields", async () => {
+    if (SKIP) {
+      console.log("Skipping: REJSEPLANEN_ACCESS_ID not set")
+      return
+    }
+    const result = await runCLI(["arrivals", "--stop", KOEBENHAVN_H, "--max", "2"])
+    const data = parseJSON<ArrivalsResponse>(result)
+
+    const arr = data.arrivals[0]
+    expect(typeof arr.name).toBe("string")
+    expect(typeof arr.line).toBe("string")
+    expect(typeof arr.origin).toBe("string")
+    expect(typeof arr.date).toBe("string")
+    expect(typeof arr.time).toBe("string")
+    expect(typeof arr.cancelled).toBe("boolean")
+    expect(typeof arr.stopId).toBe("string")
+    expect(typeof arr.delayed).toBe("boolean")
+    expect(typeof arr.delayMinutes).toBe("number")
+    expect(Array.isArray(arr.notes)).toBe(true)
+  })
+
+  test("--max param is accepted", async () => {
+    if (SKIP) {
+      console.log("Skipping: REJSEPLANEN_ACCESS_ID not set")
+      return
+    }
+    const result = await runCLI(["arrivals", "--stop", KOEBENHAVN_H, "--max", "3"])
+    const data = parseJSON<ArrivalsResponse>(result)
+    expect(data.count).toBeGreaterThan(0)
+  })
+
+  test("--format table outputs without error", async () => {
+    if (SKIP) {
+      console.log("Skipping: REJSEPLANEN_ACCESS_ID not set")
+      return
+    }
+    const result = await runCLI(["arrivals", "--stop", KOEBENHAVN_H, "--max", "3", "--format", "table"])
+    expect(result.exitCode).toBe(0)
+  })
+
+  test("--format plain outputs without error", async () => {
+    if (SKIP) {
+      console.log("Skipping: REJSEPLANEN_ACCESS_ID not set")
+      return
+    }
+    const result = await runCLI(["arrivals", "--stop", KOEBENHAVN_H, "--max", "3", "--format", "plain"])
+    expect(result.exitCode).toBe(0)
+  })
+})

--- a/skills/rejseplanen/cli/tests/commands/departures.test.ts
+++ b/skills/rejseplanen/cli/tests/commands/departures.test.ts
@@ -1,0 +1,131 @@
+import { describe, test, expect } from "bun:test"
+import { runCLI, parseJSON, hasAccessId } from "../helpers"
+
+interface DepartureItem {
+  name: string
+  line: string
+  direction: string
+  date: string
+  time: string
+  rtDate: string | null
+  rtTime: string | null
+  track: string | null
+  cancelled: boolean
+  stopId: string
+  delayed: boolean
+  delayMinutes: number
+  notes: Array<{ type: string; text: string }>
+}
+
+interface DeparturesResponse {
+  type: string
+  stop: string
+  date: string
+  time: string
+  departures: DepartureItem[]
+  count: number
+}
+
+const SKIP = !hasAccessId()
+
+// København H stop ID
+const KOEBENHAVN_H = "8600626"
+
+describe("departures command", () => {
+  test("missing --stop exits with error", async () => {
+    const result = await runCLI(["departures"])
+    expect(result.exitCode).toBe(1)
+    expect(result.stderr.toLowerCase()).toContain("error")
+  })
+
+  test("departures returns correct shape", async () => {
+    if (SKIP) {
+      console.log("Skipping: REJSEPLANEN_ACCESS_ID not set")
+      return
+    }
+    const result = await runCLI(["departures", "--stop", KOEBENHAVN_H, "--max", "3"])
+    const data = parseJSON<DeparturesResponse>(result)
+
+    expect(data.type).toBe("rejseplanen_departures")
+    expect(data.stop).toBe(KOEBENHAVN_H)
+    expect(Array.isArray(data.departures)).toBe(true)
+    expect(data.count).toBe(data.departures.length)
+    expect(data.count).toBeGreaterThan(0)
+  })
+
+  test("departure items have all expected fields", async () => {
+    if (SKIP) {
+      console.log("Skipping: REJSEPLANEN_ACCESS_ID not set")
+      return
+    }
+    const result = await runCLI(["departures", "--stop", KOEBENHAVN_H, "--max", "2"])
+    const data = parseJSON<DeparturesResponse>(result)
+
+    const dep = data.departures[0]
+    expect(typeof dep.name).toBe("string")
+    expect(typeof dep.line).toBe("string")
+    expect(typeof dep.direction).toBe("string")
+    expect(typeof dep.date).toBe("string")
+    expect(typeof dep.time).toBe("string")
+    expect(typeof dep.cancelled).toBe("boolean")
+    expect(typeof dep.stopId).toBe("string")
+    expect(typeof dep.delayed).toBe("boolean")
+    expect(typeof dep.delayMinutes).toBe("number")
+    expect(Array.isArray(dep.notes)).toBe(true)
+  })
+
+  test("--max param is accepted", async () => {
+    if (SKIP) {
+      console.log("Skipping: REJSEPLANEN_ACCESS_ID not set")
+      return
+    }
+    const result = await runCLI(["departures", "--stop", KOEBENHAVN_H, "--max", "3"])
+    const data = parseJSON<DeparturesResponse>(result)
+    expect(data.count).toBeGreaterThan(0)
+  })
+
+  test("--duration filters time window", async () => {
+    if (SKIP) {
+      console.log("Skipping: REJSEPLANEN_ACCESS_ID not set")
+      return
+    }
+    const result = await runCLI(["departures", "--stop", KOEBENHAVN_H, "--duration", "15", "--max", "5"])
+    const data = parseJSON<DeparturesResponse>(result)
+    expect(data.type).toBe("rejseplanen_departures")
+  })
+
+  test("notes have correct structure when present", async () => {
+    if (SKIP) {
+      console.log("Skipping: REJSEPLANEN_ACCESS_ID not set")
+      return
+    }
+    const result = await runCLI(["departures", "--stop", KOEBENHAVN_H, "--max", "5"])
+    const data = parseJSON<DeparturesResponse>(result)
+
+    const withNotes = data.departures.find((d) => d.notes.length > 0)
+    if (withNotes) {
+      const note = withNotes.notes[0]
+      expect(typeof note.type).toBe("string")
+      expect(typeof note.text).toBe("string")
+      expect(["bike", "accessibility", "info"]).toContain(note.type)
+    }
+  })
+
+  test("--format table outputs without error", async () => {
+    if (SKIP) {
+      console.log("Skipping: REJSEPLANEN_ACCESS_ID not set")
+      return
+    }
+    const result = await runCLI(["departures", "--stop", KOEBENHAVN_H, "--max", "3", "--format", "table"])
+    expect(result.exitCode).toBe(0)
+  })
+
+  test("--format plain outputs without error", async () => {
+    if (SKIP) {
+      console.log("Skipping: REJSEPLANEN_ACCESS_ID not set")
+      return
+    }
+    const result = await runCLI(["departures", "--stop", KOEBENHAVN_H, "--max", "3", "--format", "plain"])
+    expect(result.exitCode).toBe(0)
+  })
+})

--- a/skills/rejseplanen/cli/tests/commands/disruptions.test.ts
+++ b/skills/rejseplanen/cli/tests/commands/disruptions.test.ts
@@ -1,0 +1,81 @@
+import { describe, test, expect } from "bun:test"
+import { runCLI, parseJSON, hasAccessId } from "../helpers"
+
+interface DisruptionItem {
+  id: string
+  subject: string
+  message: string
+  priority: number
+  startDate: string
+  startTime: string
+  endDate: string
+  endTime: string
+  affectedStops: string[]
+  affectedLines: string[]
+}
+
+interface DisruptionsResponse {
+  type: string
+  date: string
+  disruptions: DisruptionItem[]
+  count: number
+}
+
+const SKIP = !hasAccessId()
+
+describe("disruptions command", () => {
+  test("disruptions returns correct shape", async () => {
+    if (SKIP) {
+      console.log("Skipping: REJSEPLANEN_ACCESS_ID not set")
+      return
+    }
+    const result = await runCLI(["disruptions", "--max", "3"])
+    const data = parseJSON<DisruptionsResponse>(result)
+
+    expect(data.type).toBe("rejseplanen_disruptions")
+    expect(typeof data.date).toBe("string")
+    expect(Array.isArray(data.disruptions)).toBe(true)
+    expect(data.count).toBe(data.disruptions.length)
+  })
+
+  test("disruption items have all expected fields", async () => {
+    if (SKIP) {
+      console.log("Skipping: REJSEPLANEN_ACCESS_ID not set")
+      return
+    }
+    const result = await runCLI(["disruptions", "--max", "3"])
+    const data = parseJSON<DisruptionsResponse>(result)
+
+    if (data.disruptions.length > 0) {
+      const d = data.disruptions[0]
+      expect(typeof d.id).toBe("string")
+      expect(typeof d.subject).toBe("string")
+      expect(typeof d.message).toBe("string")
+      expect(typeof d.priority).toBe("number")
+      expect(typeof d.startDate).toBe("string")
+      expect(typeof d.startTime).toBe("string")
+      expect(typeof d.endDate).toBe("string")
+      expect(typeof d.endTime).toBe("string")
+      expect(Array.isArray(d.affectedStops)).toBe(true)
+      expect(Array.isArray(d.affectedLines)).toBe(true)
+    }
+  })
+
+  test("--format table outputs without error", async () => {
+    if (SKIP) {
+      console.log("Skipping: REJSEPLANEN_ACCESS_ID not set")
+      return
+    }
+    const result = await runCLI(["disruptions", "--max", "3", "--format", "table"])
+    expect(result.exitCode).toBe(0)
+  })
+
+  test("--format plain outputs without error", async () => {
+    if (SKIP) {
+      console.log("Skipping: REJSEPLANEN_ACCESS_ID not set")
+      return
+    }
+    const result = await runCLI(["disruptions", "--max", "3", "--format", "plain"])
+    expect(result.exitCode).toBe(0)
+  })
+})

--- a/skills/rejseplanen/cli/tests/commands/location.test.ts
+++ b/skills/rejseplanen/cli/tests/commands/location.test.ts
@@ -1,0 +1,101 @@
+import { describe, test, expect } from "bun:test"
+import { runCLI, parseJSON, hasAccessId } from "../helpers"
+
+interface LocationItem {
+  id: string
+  name: string
+  lat: number
+  lon: number
+  type: string
+}
+
+interface LocationResponse {
+  type: string
+  query: string
+  locations: LocationItem[]
+  count: number
+}
+
+const SKIP = !hasAccessId()
+
+describe("location command", () => {
+  test("missing --query exits with error", async () => {
+    const result = await runCLI(["location"])
+    expect(result.exitCode).toBe(1)
+    expect(result.stderr.toLowerCase()).toContain("error")
+  })
+
+  test("search by name returns correct shape", async () => {
+    if (SKIP) {
+      console.log("Skipping: REJSEPLANEN_ACCESS_ID not set")
+      return
+    }
+    const result = await runCLI(["location", "--query", "København H", "--max", "3"])
+    const data = parseJSON<LocationResponse>(result)
+
+    expect(data.type).toBe("rejseplanen_location")
+    expect(data.query).toBe("København H")
+    expect(Array.isArray(data.locations)).toBe(true)
+    expect(data.count).toBe(data.locations.length)
+    expect(data.count).toBeGreaterThan(0)
+  })
+
+  test("location items have all expected fields", async () => {
+    if (SKIP) {
+      console.log("Skipping: REJSEPLANEN_ACCESS_ID not set")
+      return
+    }
+    const result = await runCLI(["location", "--query", "Nørreport", "--max", "2"])
+    const data = parseJSON<LocationResponse>(result)
+
+    expect(data.locations.length).toBeGreaterThan(0)
+    const loc = data.locations[0]
+    expect(typeof loc.id).toBe("string")
+    expect(typeof loc.name).toBe("string")
+    expect(typeof loc.lat).toBe("number")
+    expect(typeof loc.lon).toBe("number")
+    expect(typeof loc.type).toBe("string")
+  })
+
+  test("--max limits results", async () => {
+    if (SKIP) {
+      console.log("Skipping: REJSEPLANEN_ACCESS_ID not set")
+      return
+    }
+    const result = await runCLI(["location", "--query", "Station", "--max", "2"])
+    const data = parseJSON<LocationResponse>(result)
+    expect(data.count).toBeLessThanOrEqual(2)
+  })
+
+  test("--format table outputs without error", async () => {
+    if (SKIP) {
+      console.log("Skipping: REJSEPLANEN_ACCESS_ID not set")
+      return
+    }
+    const result = await runCLI(["location", "--query", "Aarhus", "--max", "2", "--format", "table"])
+    expect(result.exitCode).toBe(0)
+  })
+
+  test("--format plain outputs without error", async () => {
+    if (SKIP) {
+      console.log("Skipping: REJSEPLANEN_ACCESS_ID not set")
+      return
+    }
+    const result = await runCLI(["location", "--query", "Aarhus", "--max", "2", "--format", "plain"])
+    expect(result.exitCode).toBe(0)
+  })
+
+  test("no REJSEPLANEN_ACCESS_ID gives clear error", async () => {
+    const proc = Bun.spawn(["bun", "run", import.meta.dir + "/../../src/cli.ts", "location", "--query", "test"], {
+      stdout: "pipe",
+      stderr: "pipe",
+      env: { ...process.env, REJSEPLANEN_ACCESS_ID: "" },
+    })
+    const [stderr, exitCode] = await Promise.all([
+      new Response(proc.stderr).text(),
+      proc.exited,
+    ])
+    expect(exitCode).toBe(1)
+    expect(stderr).toContain("REJSEPLANEN_ACCESS_ID")
+  })
+})

--- a/skills/rejseplanen/cli/tests/commands/nearby.test.ts
+++ b/skills/rejseplanen/cli/tests/commands/nearby.test.ts
@@ -1,0 +1,92 @@
+import { describe, test, expect } from "bun:test"
+import { runCLI, parseJSON, hasAccessId } from "../helpers"
+
+interface NearbyStop {
+  id: string
+  name: string
+  lat: number
+  lon: number
+  dist: number
+  type: string
+}
+
+interface NearbyResponse {
+  type: string
+  lat: number
+  lon: number
+  radius: number
+  stops: NearbyStop[]
+  count: number
+}
+
+const SKIP = !hasAccessId()
+
+// Coordinates near København H
+const LAT = "55.672736"
+const LON = "12.565558"
+
+describe("nearby command", () => {
+  test("missing --lat exits with error", async () => {
+    const result = await runCLI(["nearby", "--lon", LON])
+    expect(result.exitCode).toBe(1)
+    expect(result.stderr.toLowerCase()).toContain("lat")
+  })
+
+  test("missing --lon exits with error", async () => {
+    const result = await runCLI(["nearby", "--lat", LAT])
+    expect(result.exitCode).toBe(1)
+    expect(result.stderr.toLowerCase()).toContain("lon")
+  })
+
+  test("nearby returns correct shape", async () => {
+    if (SKIP) {
+      console.log("Skipping: REJSEPLANEN_ACCESS_ID not set")
+      return
+    }
+    const result = await runCLI(["nearby", "--lat", LAT, "--lon", LON, "--max", "3"])
+    const data = parseJSON<NearbyResponse>(result)
+
+    expect(data.type).toBe("rejseplanen_nearby")
+    expect(typeof data.lat).toBe("number")
+    expect(typeof data.lon).toBe("number")
+    expect(data.radius).toBe(1000)
+    expect(Array.isArray(data.stops)).toBe(true)
+    expect(data.count).toBe(data.stops.length)
+    expect(data.count).toBeGreaterThan(0)
+  })
+
+  test("nearby stops have all expected fields", async () => {
+    if (SKIP) {
+      console.log("Skipping: REJSEPLANEN_ACCESS_ID not set")
+      return
+    }
+    const result = await runCLI(["nearby", "--lat", LAT, "--lon", LON, "--max", "2"])
+    const data = parseJSON<NearbyResponse>(result)
+
+    const stop = data.stops[0]
+    expect(typeof stop.id).toBe("string")
+    expect(typeof stop.name).toBe("string")
+    expect(typeof stop.lat).toBe("number")
+    expect(typeof stop.lon).toBe("number")
+    expect(typeof stop.dist).toBe("number")
+    expect(typeof stop.type).toBe("string")
+  })
+
+  test("--format table outputs without error", async () => {
+    if (SKIP) {
+      console.log("Skipping: REJSEPLANEN_ACCESS_ID not set")
+      return
+    }
+    const result = await runCLI(["nearby", "--lat", LAT, "--lon", LON, "--max", "3", "--format", "table"])
+    expect(result.exitCode).toBe(0)
+  })
+
+  test("--format plain outputs without error", async () => {
+    if (SKIP) {
+      console.log("Skipping: REJSEPLANEN_ACCESS_ID not set")
+      return
+    }
+    const result = await runCLI(["nearby", "--lat", LAT, "--lon", LON, "--max", "3", "--format", "plain"])
+    expect(result.exitCode).toBe(0)
+  })
+})

--- a/skills/rejseplanen/cli/tests/commands/trip.test.ts
+++ b/skills/rejseplanen/cli/tests/commands/trip.test.ts
@@ -1,0 +1,205 @@
+import { describe, test, expect } from "bun:test"
+import { runCLI, parseJSON, hasAccessId } from "../helpers"
+
+interface TripLeg {
+  name: string
+  type: string
+  origin: string
+  destination: string
+  departure: string
+  arrival: string
+  track: string | null
+  direction: string | null
+  cancelled: boolean
+  rtDeparture: string | null
+  rtArrival: string | null
+  delayed: boolean
+  delayMinutes: number
+  notes: Array<{ type: string; text: string }>
+  stops?: Array<{ name: string; arrival: string | null; departure: string | null }>
+}
+
+interface TripFare {
+  passenger: string
+  product: string
+  class: string
+  price: number
+  currency: string
+}
+
+interface TripItem {
+  origin: string
+  destination: string
+  departure: string
+  arrival: string
+  duration: string
+  changes: number
+  legs: TripLeg[]
+  fares?: TripFare[]
+}
+
+interface TripResponse {
+  type: string
+  origin: string
+  destination: string
+  date: string
+  time: string
+  trips: TripItem[]
+  tripCount: number
+  via?: string
+  scrollEarlier?: string
+  scrollLater?: string
+}
+
+const SKIP = !hasAccessId()
+
+describe("trip command", () => {
+  test("missing --origin exits with error", async () => {
+    const result = await runCLI(["trip", "--destination", "Aarhus"])
+    expect(result.exitCode).toBe(1)
+    expect(result.stderr.toLowerCase()).toContain("error")
+  })
+
+  test("missing --destination exits with error", async () => {
+    const result = await runCLI(["trip", "--origin", "København"])
+    expect(result.exitCode).toBe(1)
+    expect(result.stderr.toLowerCase()).toContain("error")
+  })
+
+  test("trip by name returns correct shape", async () => {
+    if (SKIP) {
+      console.log("Skipping: REJSEPLANEN_ACCESS_ID not set")
+      return
+    }
+    const result = await runCLI(["trip", "--origin", "København H", "--destination", "Odense", "--results", "2"])
+    const data = parseJSON<TripResponse>(result)
+
+    expect(data.type).toBe("rejseplanen_trip")
+    expect(data.origin).toBe("København H")
+    expect(data.destination).toBe("Odense")
+    expect(Array.isArray(data.trips)).toBe(true)
+    expect(data.tripCount).toBe(data.trips.length)
+    expect(data.tripCount).toBeGreaterThan(0)
+  })
+
+  test("trip items have all expected fields", async () => {
+    if (SKIP) {
+      console.log("Skipping: REJSEPLANEN_ACCESS_ID not set")
+      return
+    }
+    const result = await runCLI(["trip", "--origin", "København H", "--destination", "Odense", "--results", "1"])
+    const data = parseJSON<TripResponse>(result)
+
+    const trip = data.trips[0]
+    expect(typeof trip.origin).toBe("string")
+    expect(typeof trip.destination).toBe("string")
+    expect(typeof trip.departure).toBe("string")
+    expect(typeof trip.arrival).toBe("string")
+    expect(typeof trip.duration).toBe("string")
+    expect(typeof trip.changes).toBe("number")
+    expect(Array.isArray(trip.legs)).toBe(true)
+    expect(trip.legs.length).toBeGreaterThan(0)
+  })
+
+  test("trip legs have delay and notes fields", async () => {
+    if (SKIP) {
+      console.log("Skipping: REJSEPLANEN_ACCESS_ID not set")
+      return
+    }
+    const result = await runCLI(["trip", "--origin", "København H", "--destination", "Odense", "--results", "1"])
+    const data = parseJSON<TripResponse>(result)
+
+    const leg = data.trips[0].legs[0]
+    expect(typeof leg.delayed).toBe("boolean")
+    expect(typeof leg.delayMinutes).toBe("number")
+    expect(Array.isArray(leg.notes)).toBe(true)
+  })
+
+  test("fares included by default", async () => {
+    if (SKIP) {
+      console.log("Skipping: REJSEPLANEN_ACCESS_ID not set")
+      return
+    }
+    const result = await runCLI(["trip", "--origin", "København H", "--destination", "Odense", "--results", "1"])
+    const data = parseJSON<TripResponse>(result)
+
+    const trip = data.trips[0]
+    expect(trip.fares).toBeDefined()
+    expect(Array.isArray(trip.fares)).toBe(true)
+    if (trip.fares!.length > 0) {
+      const fare = trip.fares![0]
+      expect(typeof fare.passenger).toBe("string")
+      expect(typeof fare.product).toBe("string")
+      expect(typeof fare.class).toBe("string")
+      expect(typeof fare.price).toBe("number")
+      expect(fare.price).toBeGreaterThan(0)
+      expect(fare.currency).toBe("DKK")
+    }
+  })
+
+  test("--no-fares excludes pricing", async () => {
+    if (SKIP) {
+      console.log("Skipping: REJSEPLANEN_ACCESS_ID not set")
+      return
+    }
+    const result = await runCLI(["trip", "--origin", "København H", "--destination", "Odense", "--results", "1", "--no-fares"])
+    const data = parseJSON<TripResponse>(result)
+    expect(data.trips[0].fares).toBeUndefined()
+  })
+
+  test("scroll tokens are included", async () => {
+    if (SKIP) {
+      console.log("Skipping: REJSEPLANEN_ACCESS_ID not set")
+      return
+    }
+    const result = await runCLI(["trip", "--origin", "København H", "--destination", "Odense", "--results", "2"])
+    const data = parseJSON<TripResponse>(result)
+    expect(typeof data.scrollEarlier).toBe("string")
+    expect(typeof data.scrollLater).toBe("string")
+  })
+
+  test("--stops includes intermediate stops", async () => {
+    if (SKIP) {
+      console.log("Skipping: REJSEPLANEN_ACCESS_ID not set")
+      return
+    }
+    const result = await runCLI(["trip", "--origin", "København H", "--destination", "Odense", "--results", "1", "--stops"])
+    const data = parseJSON<TripResponse>(result)
+
+    const transitLeg = data.trips[0].legs.find((l) => l.type !== "WALK")
+    if (transitLeg) {
+      expect(transitLeg.stops).toBeDefined()
+      expect(Array.isArray(transitLeg.stops)).toBe(true)
+      expect(transitLeg.stops!.length).toBeGreaterThan(0)
+      expect(typeof transitLeg.stops![0].name).toBe("string")
+    }
+  })
+
+  test("--results limits trip count", async () => {
+    if (SKIP) {
+      console.log("Skipping: REJSEPLANEN_ACCESS_ID not set")
+      return
+    }
+    const result = await runCLI(["trip", "--origin", "København H", "--destination", "Aarhus H", "--results", "1"])
+    const data = parseJSON<TripResponse>(result)
+    expect(data.tripCount).toBeLessThanOrEqual(2)
+  })
+
+  test("--format table outputs without error", async () => {
+    if (SKIP) {
+      console.log("Skipping: REJSEPLANEN_ACCESS_ID not set")
+      return
+    }
+    const result = await runCLI(["trip", "--origin", "København H", "--destination", "Odense", "--results", "1", "--format", "table"])
+    expect(result.exitCode).toBe(0)
+  })
+
+  test("--format plain outputs without error", async () => {
+    if (SKIP) {
+      console.log("Skipping: REJSEPLANEN_ACCESS_ID not set")
+      return
+    }
+    const result = await runCLI(["trip", "--origin", "København H", "--destination", "Odense", "--results", "1", "--format", "plain"])
+    expect(result.exitCode).toBe(0)
+  })
+})

--- a/skills/rejseplanen/cli/tests/helpers.ts
+++ b/skills/rejseplanen/cli/tests/helpers.ts
@@ -1,0 +1,44 @@
+import { join } from "path"
+
+const CLI_PATH = join(import.meta.dir, "../src/cli.ts")
+
+export interface CLIResult {
+  stdout: string
+  stderr: string
+  exitCode: number
+}
+
+export async function runCLI(args: string[]): Promise<CLIResult> {
+  const proc = Bun.spawn(["bun", "run", CLI_PATH, ...args], {
+    stdout: "pipe",
+    stderr: "pipe",
+    env: { ...process.env },
+  })
+
+  const [stdout, stderr, exitCode] = await Promise.all([
+    new Response(proc.stdout).text(),
+    new Response(proc.stderr).text(),
+    proc.exited,
+  ])
+
+  return { stdout: stdout.trim(), stderr: stderr.trim(), exitCode }
+}
+
+export function parseJSON<T = unknown>(result: CLIResult): T {
+  if (result.exitCode !== 0) {
+    throw new Error(
+      `CLI exited with code ${result.exitCode}. stderr: ${result.stderr}`
+    )
+  }
+  try {
+    return JSON.parse(result.stdout) as T
+  } catch {
+    throw new Error(
+      `Failed to parse JSON. stdout: ${result.stdout}\nstderr: ${result.stderr}`
+    )
+  }
+}
+
+export function hasAccessId(): boolean {
+  return Boolean(process.env.REJSEPLANEN_ACCESS_ID)
+}

--- a/skills/rejseplanen/cli/tsconfig.json
+++ b/skills/rejseplanen/cli/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "lib": ["ESNext"],
+    "types": ["bun-types"],
+    "strict": true,
+    "noImplicitAny": true,
+    "strictNullChecks": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true,
+    "skipLibCheck": true,
+    "outDir": "dist",
+    "rootDir": "."
+  },
+  "include": ["src/**/*", "tests/**/*"],
+  "exclude": ["node_modules", "dist"]
+}


### PR DESCRIPTION
New skill with 6 commands for journey planning via the Rejseplanen API:
- location: search stops/stations by name
- trip: plan journeys with fares, via routing, intermediate stops, scroll pagination
- departures/arrivals: real-time boards with delay calculation and bike/wheelchair notes
- nearby: find stops by coordinates
- disruptions: service alerts from HIM

All 43 tests hit the live API per contributing guidelines.

Fixes #10