### PR TITLE
fix(jobindex-search): parse client-side Stash payload after JSON endpoint retired

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 - **rejseplanen** — Danish public transport journey planning via the Rejseplanen API (6 commands: location, trip, departures, arrivals, nearby, disruptions)
 
+### Fixed
+
+- **jobindex-search** — `search` command broke after Jobindex retired its `/jobsoegning.json` endpoint (now returns `204 No Content`) and moved results client-side. The command now fetches the `/jobsoegning` HTML page and parses the embedded `var Stash = {...}` payload (`searchResponse.results` + `hitcount`). Results gain a `deadline` field.
+
 ## [1.0.0] - 2026-03-13
 
 ### Added

--- a/skills/jobindex-search/cli/src/commands/search.ts
+++ b/skills/jobindex-search/cli/src/commands/search.ts
@@ -1,11 +1,6 @@
 import { defineCommand, option } from "@bunli/core"
 import { z } from "zod"
-import { apiFetch, parseJobCards, parseHitCount, writeError } from "../helpers.js"
-
-interface SearchAPIResponse {
-  result_list_box_html: string
-  hitcount_html: string
-}
+import { BASE_URL, htmlFetch, parseSearchPage, writeError, type JobCard } from "../helpers.js"
 
 export const search = defineCommand({
   name: "search",
@@ -39,20 +34,21 @@ export const search = defineCommand({
 
     if (signal.aborted) return
 
-    const params: Record<string, string> = {
+    const params = new URLSearchParams({
       q: flags.query,
       page: String(flags.page),
       jobage: String(flags.jobage),
       sort: flags.sort,
-    }
+    })
 
     try {
-      const data = await apiFetch<SearchAPIResponse>("/jobsoegning.json", params)
+      const html = await htmlFetch(`${BASE_URL}/jobsoegning?${params.toString()}`)
 
       if (signal.aborted) return
 
-      const total = parseHitCount(data.hitcount_html ?? "")
-      let results = parseJobCards(data.result_list_box_html ?? "")
+      const parsed = parseSearchPage(html)
+      const total = parsed.total
+      let results = parsed.results
 
       if (flags.limit !== undefined) {
         results = results.slice(0, flags.limit)
@@ -81,7 +77,7 @@ export const search = defineCommand({
   },
 })
 
-function outputTable(results: ReturnType<typeof parseJobCards>): void {
+function outputTable(results: JobCard[]): void {
   console.log("id          title                                    company              location")
   for (const r of results) {
     const id = r.id.padEnd(11)
@@ -92,13 +88,14 @@ function outputTable(results: ReturnType<typeof parseJobCards>): void {
   }
 }
 
-function outputPlain(results: ReturnType<typeof parseJobCards>): void {
+function outputPlain(results: JobCard[]): void {
   for (const r of results) {
     console.log(`id: ${r.id}`)
     console.log(`title: ${r.title}`)
     console.log(`company: ${r.company ?? "-"}`)
     console.log(`location: ${r.location ?? "-"}`)
     console.log(`date: ${r.date ?? "-"}`)
+    console.log(`deadline: ${r.deadline ?? "-"}`)
     console.log(`url: ${r.url}`)
     if (r.description) console.log(`description: ${r.description}`)
     console.log("")

--- a/skills/jobindex-search/cli/src/helpers.ts
+++ b/skills/jobindex-search/cli/src/helpers.ts
@@ -71,8 +71,113 @@ export interface JobCard {
   companyUrl: string | null
   location: string | null
   date: string | null
+  deadline: string | null
   url: string
   description: string | null
+}
+
+/**
+ * Jobindex moved its search results client-side. The /jobsoegning.json endpoint
+ * now returns 204 No Content. The HTML page (/jobsoegning) embeds the full result
+ * payload in a `var Stash = {...}` script blob, under
+ * jobsearch/result_app -> storeData -> searchResponse -> { hitcount, results[] }.
+ * This extracts and parses that blob.
+ */
+export function extractStash(html: string): any {
+  const marker = "var Stash = "
+  const start = html.indexOf(marker)
+  if (start === -1) throw new Error("Could not locate Stash blob in jobindex HTML")
+  const open = start + marker.length
+  let depth = 0
+  let inStr = false
+  let esc = false
+  let end = -1
+  for (let j = open; j < html.length; j++) {
+    const c = html[j]
+    if (inStr) {
+      if (esc) esc = false
+      else if (c === "\\") esc = true
+      else if (c === '"') inStr = false
+    } else {
+      if (c === '"') inStr = true
+      else if (c === "{") depth++
+      else if (c === "}") {
+        depth--
+        if (depth === 0) {
+          end = j + 1
+          break
+        }
+      }
+    }
+  }
+  if (end === -1) throw new Error("Unterminated Stash blob in jobindex HTML")
+  return JSON.parse(html.slice(open, end))
+}
+
+function findSearchResponse(node: any): any {
+  if (node && typeof node === "object") {
+    if (!Array.isArray(node)) {
+      if (
+        node.searchResponse &&
+        typeof node.searchResponse === "object" &&
+        Array.isArray(node.searchResponse.results)
+      ) {
+        return node.searchResponse
+      }
+      for (const key of Object.keys(node)) {
+        const found = findSearchResponse(node[key])
+        if (found) return found
+      }
+    } else {
+      for (const item of node) {
+        const found = findSearchResponse(item)
+        if (found) return found
+      }
+    }
+  }
+  return null
+}
+
+export interface SearchPageResult {
+  total: number
+  results: JobCard[]
+}
+
+export function parseSearchPage(html: string): SearchPageResult {
+  const stash = extractStash(html)
+  const sr = findSearchResponse(stash)
+  if (!sr) throw new Error("Could not locate searchResponse in jobindex Stash")
+
+  const results: JobCard[] = (sr.results ?? []).map((r: any): JobCard => {
+    const tid: string = r.tid ?? ""
+    let location: string | null = r.area ?? null
+    if (!location) {
+      try {
+        location = r.geojson?.features?.[0]?.properties?.title ?? null
+      } catch {
+        location = null
+      }
+    }
+    let deadline: string | null = null
+    if (r.apply_deadline_asap) deadline = "ASAP"
+    else if (typeof r.apply_deadline === "string") deadline = r.apply_deadline.slice(0, 10)
+    else if (typeof r.lastdate === "string") deadline = r.lastdate
+
+    return {
+      id: tid,
+      title: r.headline ?? "",
+      company: r.company?.name ?? r.companytext ?? null,
+      companyUrl: r.company?.homeurl ?? null,
+      location,
+      date: r.firstdate ?? null,
+      deadline,
+      url: tid ? `${BASE_URL}/jobannonce/${tid}` : (r.share_url ?? r.url ?? ""),
+      description: null,
+    }
+  })
+
+  const total = typeof sr.hitcount === "number" ? sr.hitcount : results.length
+  return { total, results }
 }
 
 /**
@@ -181,6 +286,7 @@ export function parseJobCards(html: string): JobCard[] {
       companyUrl: companyUrl || null,
       location: location || null,
       date: date || null,
+      deadline: null,
       url,
       description: description || null,
     })


### PR DESCRIPTION
## Problem

The `jobindex-search` `search` command is currently broken. Jobindex retired the `/jobsoegning.json` endpoint the command relied on; it now returns **`204 No Content`**, so every search fails with:

```
{"error":"null is not an object (evaluating 'data.hitcount_html')","code":"API_ERROR"}
```

## Root cause

Jobindex moved its search results client-side. The `/jobsoegning` HTML page now embeds the full result payload in a `var Stash = {...}` script blob, under:

```
jobsearch/result_app → storeData → searchResponse → { hitcount, results[] }
```

## Fix

Switch `search` from the dead JSON endpoint to fetching the HTML page and parsing that blob:

- **`extractStash()`** — string-aware brace-matching to slice out the `var Stash = {...}` JSON literal, then `JSON.parse`.
- **`findSearchResponse()`** — recursively locates `searchResponse` (resilient to the surrounding store-path shifting).
- **`parseSearchPage()`** — maps each result (`tid`, `headline`, `company.name`, `area`, `firstdate`, `apply_deadline`) to a `JobCard`. Canonical URL is `https://www.jobindex.dk/jobannonce/<tid>`; `hitcount` becomes `meta.total`.

`JobCard` gains a **`deadline`** field (from `apply_deadline`/`lastdate`), exposed in JSON and `plain` output. The legacy `parseJobCards` / `parseHitCount` / `apiFetch` helpers are left intact.

## Verification

- `bun test` — **16 search + 10 detail tests pass** against the live site (no changes to the public `{ meta, results }` contract; `id` still `h`-prefixed, URLs still `jobindex.dk`, pagination intact).
- `bun run typecheck` (`tsc --noEmit`) — clean.
- `CHANGELOG.md` updated under `[Unreleased] → Fixed`.

The `search` flag interface is unchanged (`--query/--page/--jobage/--sort/--limit/--format`).